### PR TITLE
hydra install chmod commands modified

### DIFF
--- a/scripts/hydra
+++ b/scripts/hydra
@@ -206,10 +206,11 @@ install() {
   echo "Installing hydra ..."
   echo "Installing Framework..."
   create_template project $PROJECT_NAME
-  chmod -R a+rwx infra/docker/monitoring/grafana/storage
-  chmod -R +w .git
-  rm -r .git
-  echo "Hydra requires write access to the infra directory. Run: 'chmod -R a+rwx infra' before continuing."
+  chmod a+rwx infra/docker/monitoring/grafana/storage
+  if [ -d ".git" ]; then
+    chmod -R +w .git
+    rm -r .git
+  fi
   echo "Installed"
 }
 


### PR DESCRIPTION
I removed the recursive chmod parameter from the grafana/storage chmod.  I don't think it needs it. I noticed when running a hydra install a second time it would give errors from the .git folder, due to it being removed already.  So I added a check to see if the directory exists.  If it exists then it proceeds with the chmod command and removing the directory.

I also removed the message asking the user to chmod the infra directory.  It doesn't seem needed anymore.  As long as the storage folder is chmod I think everything else is fine.