### PR TITLE
Hydra bash shebang interpreter directive

### DIFF
--- a/scripts/hydra
+++ b/scripts/hydra
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 if [ -x "$(command -v docker-compose)" ]; then
   # Version 1 syntax
   dockercompose="docker-compose"

--- a/scripts/hydra-update
+++ b/scripts/hydra-update
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 check_if_container_is_running() {
   if docker ps --format '{{.Names}}' | grep "$1"; then
     echo You should stop the container $1 before update


### PR DESCRIPTION
Add the bash shebang interpreter directive line to the hydra scripts.
This makes the scripts compatible for shells that don't use bash by default (like ZSH, which uses sh by default).