### PR TITLE
Adding hydra remote start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ infra/docker/monitoring/prometheus/data/
 infra/docker/monitoring/prometheus/monitoring/
 .idea
 infra/docker/shared/jars/**.jar
+.vscode

--- a/README.md
+++ b/README.md
@@ -195,11 +195,42 @@ In this tool we have 2 dashboards, you can access them on `Dashboard` section
 
 ## Deployment
 
-Configuring, deploying, and starting to remote node instances is supported through Ansible playbooks. The default settings deploy to three node instances via SSH which host all layers of your metagraph project (gL0, mL0, cL1, dL1). Two hydra methods are available to help with the deployment process: `hydra remote_deploy` and `hydra remote_start`.
+Configuring, deploying, and starting remote node instances is supported through Ansible playbooks. The default settings deploy to three node instances via SSH which host all layers of your metagraph project (gL0, mL0, cL1, dL1). Two hydra methods are available to help with the deployment process: `hydra remote_deploy` and `hydra remote_start`.
 Prior to running these methods, remote host information must be configured in  `infra/ansible/hosts.ansible.yml`
 
+
+### Host Configuration
+
+To run your metagraph remotely, you'll need remote hosts—ideally, at least three of them. These hosts should be running either `ubuntu-20.04` or `ubuntu-22.04`. It's recommended that each host meets the following minimum requirements:
+
+-   16GB of RAM
+-   8vCPU
+-   160GB of storage
+
+You can choose your preferred platform for hosting your instances, such as AWS or DigitalOcean. After creating your hosts, you'll need to provide the following information in the `hosts.ansible.yml` file:
+
+-   Host IP
+-   Host user
+-   Host SSH key (optional if your localhost already has access to the remote host)
+
+### P12 Files
+
+These files serve as your token files and should be located in the `source/p12-files` directory by default. Details such as the `file-name`, `key-alias`, and `password` should be specified in the `euclid.json` file under the `p12_files` section. By default, Euclid comes with three example files: `token-key.p12`, `token-key-1.p12`, and `token-key-2.p12`. **NOTE:** Before deploying, be sure to replace these example files with your own, as these files are public and their credentials are shared.
+
+Each `p12` file contains a `peerId`, and each node is associated with a `peerId`. **NOTE:** Ensure that your peerIDs are registered on the MainNet network. Otherwise, the metagraph startup will fail because the network will reject the snapshots.
+
+### Network Selection
+
+Currently, there are three networks available for running your metagraph: `TestNet`, `IntegrationNet`, and `MainNet`. You need to specify the network on which your metagraph will run in the `euclid.json` file under `deploy -> network -> name`.
+
+### GL0 Node Configuration
+
+The deploy script does not deploy the `gl0` node. It's recommended to use `nodectl` to build your `gl0` node. Information on installing `nodectl` can be found [here](https://docs.constellationnetwork.io/validate/automated/nodectl). `Nodectl` helps manage `gl0` nodes by providing tools such as `auto-upgrade` and `auto-restart`.
+
+**NOTE:** Your GL0 node must be up and running before deploying your metagraph. You can use the same host to run all four layers: `gl0`, `ml0`, `cl1`, and `dl1`.
+
 ### `hydra remote_deploy`
-This method configures remote instances with all the necessary dependencies to run a Metagraph, including Java, Scala, and required build tools. The Ansible playbook used for this process can be found and edited in `infra/ansible/playbooks/deploy.ansible.yml`. Also, creates all required directories on the remote hosts, and creates or updates metagraph files to match your local Euclid environment. Specifically, it creates the following directories:
+This method configures remote instances with all the necessary dependencies to run a metagraph, including Java, Scala, and required build tools. The Ansible playbook used for this process can be found and edited in `infra/ansible/playbooks/deploy.ansible.yml`. It also creates all required directories on the remote hosts, and creates or updates metagraph files to match your local Euclid environment. Specifically, it creates the following directories:
 
 -   `code/global-l0`
 -   `code/metagraph-l0`
@@ -223,14 +254,14 @@ Each directory will be created with `cl-keytool.jar`, `cl-wallet.jar`, and a P12
 
 ### `hydra remote_start`
 
-This method initiates the remote startup of your metagraph in one of the available networks: testnet, integrationnet, and mainnet.
+This method initiates the remote startup of your metagraph in one of the available networks: testnet, integrationnet, and mainnet. The network should be set in `euclid.json` under `deploy` -> `network`
 
-To commence the remote startup of the metagraph, we utilize the parameters configured on Euclid. The startup process unfolds as follows:
+To begin the remote startup of the metagraph, we utilize the parameters configured in euclid.json (`network`, `gl0_node -> ip`, `gl0_node -> id`, `gl0_node -> public_port`, `ansible -> hosts`, and `ansible -> playbooks -> start`). The startup process unfolds as follows:
 
-1.  Termination of any processes currently running on the metagraph ports, which by default are 7000 for ml0, 8000 for cl1, and 9000 for dl1.
-2.  Relocation of any existing logs to a folder named `older-logs`, residing within each layer directory: `metagraph-l0`, `currency-l1`, and `data-l1`.
+1.  Termination of any processes currently running on the metagraph ports, which by default are 7000 for ml0, 8000 for cl1, and 9000 for dl1 (you can change on `hosts.ansible.yml`).
+2.  Relocation of any existing logs to a folder named `archived-logs`, residing within each layer directory: `metagraph-l0`, `currency-l1`, and `data-l1`.
 3.  Initiation of the `metagraph-l0` layer, with `node-1` designated as the genesis node.
-4.  Initial startup as `genesis`, transitioning to `rollback` for subsequent executions. To force a genesis startup, utilize the `--force_genesis` flag with the `hydra remote_start` command.  This will move the current `data` directory to a folder named `older-datas`.
+4.  Initial startup as `genesis`, transitioning to `rollback` for subsequent executions. To force a genesis startup, utilize the `--force_genesis` flag with the `hydra remote_start` command.  This will move the current `data` directory to a folder named `archived-data`.
 5.  Detection of missing files required for layer execution, such as `:your_file.p12` and `metagraph-l0.jar`, triggering an error and halting execution.
 6.  Following the initiation of `metagraph-l0`, the l1 layers, namely `currency-l1` and `data-l1`, are started. These layers only commence if their respective JARs are present in the directories. Unlike `metagraph-l0`, the absence of JARs does not prompt an error but rather prevents startup.
 
@@ -240,5 +271,4 @@ After the script completes execution, you can verify if your metagraph is genera
 -   Integrationnet: [https://be-integrationnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest](https://be-integrationnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest)
 -   Mainnet: [https://be-mainnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest](https://be-mainnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest)
 
-**NOTE:** Ensure that your peerIDs are registered on the desired network; otherwise, the metagraph startup will fail because the network will reject the snapshots.
 **NOTE:** Don't forget to add your hosts' information, such as host, user, and SSH key file, to your `infra/ansible/hosts.ansible.yml` file.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Prior to running these methods, remote host information must be configured in  `
 
 ### Host Configuration
 
-To run your metagraph remotely, you'll need remote hosts—ideally, at least three of them. These hosts should be running either `ubuntu-20.04` or `ubuntu-22.04`. It's recommended that each host meets the following minimum requirements:
+To run your metagraph remotely, you'll need remote server instances - 3 instances for the default configuration. These hosts should be running either `ubuntu-20.04` or `ubuntu-22.04`. It's recommended that each host meets the following minimum requirements:
 
 -   16GB of RAM
 -   8vCPU
@@ -211,21 +211,22 @@ You can choose your preferred platform for hosting your instances, such as AWS o
 
 -   Host IP
 -   Host user
--   Host SSH key (optional if your localhost already has access to the remote host)
+-   Host SSH key (optional if your default SSH token already has access to the remote host)
 
 ### P12 Files
 
-These files serve as your token files and should be located in the `source/p12-files` directory by default. Details such as the `file-name`, `key-alias`, and `password` should be specified in the `euclid.json` file under the `p12_files` section. By default, Euclid comes with three example files: `token-key.p12`, `token-key-1.p12`, and `token-key-2.p12`. **NOTE:** Before deploying, be sure to replace these example files with your own, as these files are public and their credentials are shared.
+P12 files contain the public/private key pair identifying each node (peerID) and should be located in the `source/p12-files` directory by default. The `file-name`, `key-alias`, and `password` should be specified in the `euclid.json` file under the `p12_files` section. By default, Euclid comes with three example files: `token-key.p12`, `token-key-1.p12`, and `token-key-2.p12`. **NOTE:** Before deploying, be sure to replace these example files with your own, as these files are public and their credentials are shared.
 
-Each `p12` file contains a `peerId`, and each node is associated with a `peerId`. **NOTE:** Ensure that your peerIDs are registered on the MainNet network. Otherwise, the metagraph startup will fail because the network will reject the snapshots.
+**NOTE:** If deploying to MainNet, ensure that your peerIDs are registered and present on the metagraph seedlist. Otherwise, the metagraph startup will fail because the network will reject the snapshots.
+
 
 ### Network Selection
 
-Currently, there are three networks available for running your metagraph: `TestNet`, `IntegrationNet`, and `MainNet`. You need to specify the network on which your metagraph will run in the `euclid.json` file under `deploy -> network -> name`.
+Currently, there are two networks available for running your metagraph: `IntegrationNet`, and `MainNet`. You need to specify the network on which your metagraph will run in the `euclid.json` file under `deploy -> network -> name`.
 
 ### GL0 Node Configuration
 
-The deploy script does not deploy the `gl0` node. It's recommended to use `nodectl` to build your `gl0` node. Information on installing `nodectl` can be found [here](https://docs.constellationnetwork.io/validate/automated/nodectl). `Nodectl` helps manage `gl0` nodes by providing tools such as `auto-upgrade` and `auto-restart`.
+The deploy script does not deploy the `gl0` node. It's recommended to use `nodectl` to build your `gl0` node. Information on installing `nodectl` can be found [here](https://docs.constellationnetwork.io/validate/automated/nodectl). `Nodectl` helps manage `gl0` nodes by providing tools such as `auto-upgrade` and `auto-restart` which keep the node online in the case of a disconnection or network upgrade. Using these features is highly recommended for the stability of your metagraph. 
 
 **NOTE:** Your GL0 node must be up and running before deploying your metagraph. You can use the same host to run all four layers: `gl0`, `ml0`, `cl1`, and `dl1`.
 
@@ -254,21 +255,34 @@ Each directory will be created with `cl-keytool.jar`, `cl-wallet.jar`, and a P12
 
 ### `hydra remote_start`
 
-This method initiates the remote startup of your metagraph in one of the available networks: testnet, integrationnet, and mainnet. The network should be set in `euclid.json` under `deploy` -> `network`
+This method initiates the remote startup of your metagraph in one of the available networks: integrationnet or mainnet. The network should be set in `euclid.json` under `deploy` -> `network`
 
 To begin the remote startup of the metagraph, we utilize the parameters configured in euclid.json (`network`, `gl0_node -> ip`, `gl0_node -> id`, `gl0_node -> public_port`, `ansible -> hosts`, and `ansible -> playbooks -> start`). The startup process unfolds as follows:
 
 1.  Termination of any processes currently running on the metagraph ports, which by default are 7000 for ml0, 8000 for cl1, and 9000 for dl1 (you can change on `hosts.ansible.yml`).
 2.  Relocation of any existing logs to a folder named `archived-logs`, residing within each layer directory: `metagraph-l0`, `currency-l1`, and `data-l1`.
 3.  Initiation of the `metagraph-l0` layer, with `node-1` designated as the genesis node.
-4.  Initial startup as `genesis`, transitioning to `rollback` for subsequent executions. To force a genesis startup, utilize the `--force_genesis` flag with the `hydra remote_start` command.  This will move the current `data` directory to a folder named `archived-data`.
+4.  Initial startup as `genesis`, transitioning to `rollback` for subsequent executions. To force a genesis startup, utilize the `--force_genesis` flag with the `hydra remote_start` command.  This will move the current `data` directory to a folder named `archived-data` and restart the metagraph from the first snapshot.
 5.  Detection of missing files required for layer execution, such as `:your_file.p12` and `metagraph-l0.jar`, triggering an error and halting execution.
-6.  Following the initiation of `metagraph-l0`, the l1 layers, namely `currency-l1` and `data-l1`, are started. These layers only commence if their respective JARs are present in the directories. Unlike `metagraph-l0`, the absence of JARs does not prompt an error but rather prevents startup.
+6.  Following the initiation of `metagraph-l0`, the l1 layers, namely `currency-l1` and `data-l1`, are started. These layers only started if present in your project. 
 
 After the script completes execution, you can verify if your metagraph is generating snapshots by checking the block explorer of the selected network:
 
--   Testnet: [https://be-testnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest](https://be-testnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest)
 -   Integrationnet: [https://be-integrationnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest](https://be-integrationnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest)
 -   Mainnet: [https://be-mainnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest](https://be-mainnet.constellationnetwork.io/currency/:your_metagraph_id/snapshots/latest)
+
+
+You can verify if the cluster was successfully built by accessing the following URL:
+
+`http://{your_host_ip}:{your_layer_port}/cluster.info` 
+
+Replace:
+
+-   `{your_host_ip}`: Provide your host's IP address.
+-   `{your_layer_port}`: Enter the public port you assigned to each layer.
+
+Each layer directory on every node contains a folder named `logs`. You can monitor and track your metagraph logs by running:
+
+`tail -f logs/app.log`
 
 **NOTE:** Don't forget to add your hosts' information, such as host, user, and SSH key file, to your `infra/ansible/hosts.ansible.yml` file.

--- a/euclid.json
+++ b/euclid.json
@@ -39,9 +39,21 @@
       "monitoring"
     ]
   },
-  "ansible": {
-    "hosts_file": "infra/ansible/hosts.ansible.yml",
-    "configure_playbook_file": "infra/ansible/playbooks/configure.ansible.yml",
-    "deploy_playbook_file": "infra/ansible/playbooks/deploy.ansible.yml"
+  "deploy": {
+    "network": {
+      "name": "testnet|integrationnet|mainnet",
+      "node": {
+        "ip": ":gl0_node_ip",
+        "id": ":gl0_node_id",
+        "public_port": ":gl0_node_public_port"
+      }
+    },
+    "ansible": {
+      "hosts": "infra/ansible/hosts.ansible.yml",
+      "playbooks": {
+        "deploy": "infra/ansible/playbooks/deploy/deploy.ansible.yml",
+        "start": "infra/ansible/playbooks/start/start.ansible.yml"
+      }
+    }
   }
 }

--- a/euclid.json
+++ b/euclid.json
@@ -42,7 +42,7 @@
   "deploy": {
     "network": {
       "name": "testnet|integrationnet|mainnet",
-      "node": {
+      "gl0_node": {
         "ip": ":gl0_node_ip",
         "id": ":gl0_node_id",
         "public_port": ":gl0_node_public_port"

--- a/euclid.json
+++ b/euclid.json
@@ -41,7 +41,7 @@
   },
   "deploy": {
     "network": {
-      "name": "testnet|integrationnet|mainnet",
+      "name": "integrationnet|mainnet",
       "gl0_node": {
         "ip": ":gl0_node_ip",
         "id": ":gl0_node_id",

--- a/infra/ansible/hosts.ansible.yml
+++ b/infra/ansible/hosts.ansible.yml
@@ -16,3 +16,12 @@ nodes:
 
   vars:
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    metagraph_l0_public_port: 7000
+    metagraph_l0_p2p_port: 7001
+    metagraph_l0_cli_port: 7002
+    currency_l1_public_port: 8000
+    currency_l1_p2p_port: 8001
+    currency_l1_cli_port: 8002
+    data_l1_public_port: 9000
+    data_l1_p2p_port: 9001
+    data_l1_cli_port: 9002

--- a/infra/ansible/playbooks/deploy/configure.ansible.yml
+++ b/infra/ansible/playbooks/deploy/configure.ansible.yml
@@ -2,7 +2,7 @@
 - name: Install nodes dependencies
   hosts: nodes
   become: true
-
+  gather_facts: false  
   tasks:
     - name: Update APT package cache
       apt:

--- a/infra/ansible/playbooks/deploy/deploy.ansible.yml
+++ b/infra/ansible/playbooks/deploy/deploy.ansible.yml
@@ -1,7 +1,9 @@
 ---
+- import_playbook: configure.ansible.yml
+
 - name: Create directories on remote hosts
   hosts: nodes
-  become: true
+  gather_facts: false
   tasks:
     - name: Create global-l0 directory
       file:
@@ -25,140 +27,135 @@
 
 - name: Send JARs to remote hosts
   hosts: nodes
-  become: true
+  gather_facts: false
   tasks:
     - name: Sending cl-keytool.jar to global-l0
       copy:
-        src: ../../docker/shared/jars/cl-keytool.jar
+        src: ../../../docker/shared/jars/cl-keytool.jar
         dest: /home/{{ ansible_user }}/code/global-l0
 
     - name: Sending cl-wallet.jar to global-l0
       copy:
-        src: ../../docker/shared/jars/cl-wallet.jar
+        src: ../../../docker/shared/jars/cl-wallet.jar
         dest: /home/{{ ansible_user }}/code/global-l0
 
     - name: Sending cl-keytool.jar to metagraph-l0
       copy:
-        src: ../../docker/shared/jars/cl-keytool.jar
+        src: ../../../docker/shared/jars/cl-keytool.jar
         dest: /home/{{ ansible_user }}/code/metagraph-l0
 
     - name: Sending cl-wallet.jar to metagraph-l0
       copy:
-        src: ../../docker/shared/jars/cl-wallet.jar
+        src: ../../../docker/shared/jars/cl-wallet.jar
         dest: /home/{{ ansible_user }}/code/metagraph-l0
 
     - name: Sending metagraph-l0.jar to metagraph-l0
       copy:
-        src: ../../docker/shared/jars/cl-wallet.jar
-        dest: /home/{{ ansible_user }}/code/metagraph-l0
-        
-    - name: Sending metagraph-l0.jar to metagraph-l0
-      copy:
-        src: ../../docker/shared/jars/cl-wallet.jar
+        src: ../../../docker/shared/jars/metagraph-l0.jar
         dest: /home/{{ ansible_user }}/code/metagraph-l0
 
     - name: Sending cl-keytool.jar to currency-l1
       copy:
-        src: ../../docker/shared/jars/cl-keytool.jar
+        src: ../../../docker/shared/jars/cl-keytool.jar
         dest: /home/{{ ansible_user }}/code/currency-l1
     
     - name: Sending cl-wallet.jar to currency-l1
       copy:
-        src: ../../docker/shared/jars/cl-wallet.jar
+        src: ../../../docker/shared/jars/cl-wallet.jar
         dest: /home/{{ ansible_user }}/code/currency-l1
 
     - name: Sending metagraph-l1-currency.jar to currency-l1
       copy:
-        src: ../../docker/shared/jars/metagraph-l1-currency.jar
+        src: ../../../docker/shared/jars/metagraph-l1-currency.jar
         dest: /home/{{ ansible_user }}/code/currency-l1/currency-l1.jar
 
     - name: Sending cl-keytool.jar to data-l1
       copy:
-        src: ../../docker/shared/jars/cl-keytool.jar
+        src: ../../../docker/shared/jars/cl-keytool.jar
         dest: /home/{{ ansible_user }}/code/data-l1
 
     - name: Sending cl-wallet.jar to data-l1
       copy:
-        src: ../../docker/shared/jars/cl-wallet.jar
+        src: ../../../docker/shared/jars/cl-wallet.jar
         dest: /home/{{ ansible_user }}/code/data-l1
 
     - name: Sending metagraph-l1-data.jar to data-l1
       copy:
-        src: ../../docker/shared/jars/metagraph-l1-data.jar
+        src: ../../../docker/shared/jars/metagraph-l1-data.jar
         dest: /home/{{ ansible_user }}/code/data-l1/data-l1.jar
 
 - name: Send genesis information to remote hosts
   hosts: nodes
-  become: true
+  gather_facts: false
   tasks:
     - name: Sending metagraph l0 genesis.csv to metagraph-l0
       copy:
-        src: ../../../source/metagraph-l0/genesis/genesis.csv
+        src: ../../../../source/metagraph-l0/genesis/genesis.csv
         dest: /home/{{ ansible_user }}/code/metagraph-l0
 
     - name: Sending metagraph l0 genesis.snapshot to metagraph-l0
       copy:
-        src: ../../../source/metagraph-l0/genesis/genesis.snapshot
+        src: ../../../../source/metagraph-l0/genesis/genesis.snapshot
         dest: /home/{{ ansible_user }}/code/metagraph-l0
 
     - name: Sending metagraph l0 genesis.address to metagraph-l0
       copy:
-        src: ../../../source/metagraph-l0/genesis/genesis.address
+        src: ../../../../source/metagraph-l0/genesis/genesis.address
         dest: /home/{{ ansible_user }}/code/metagraph-l0
 
 - name: Send p12 files to remote node-1
   hosts: node-1
-  become: true
+  gather_facts: false
   tasks:
     - name: Sending p12 file to metagraph-l0
       copy:
-        src: ../../../source/p12-files/{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}
+        src: ../../../../source/p12-files/{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/metagraph-l0
         
     - name: Sending p12 file to currency-l1
       copy:
-        src: ../../../source/p12-files/{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}
+        src: ../../../../source/p12-files/{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/currency-l1
 
     - name: Sending p12 file to data-l1
       copy:
-        src: ../../../source/p12-files/{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}
+        src: ../../../../source/p12-files/{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/data-l1
 
 - name: Send p12 files to remote node-2
   hosts: node-2
-  become: true
+  gather_facts: false
   tasks:
     - name: Sending p12 file to metagraph-l0
       copy:
-        src: ../../../source/p12-files/{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}
+        src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/metagraph-l0
         
     - name: Sending p12 file to currency-l1
       copy:
-        src: ../../../source/p12-files/{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}
+        src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/currency-l1
 
     - name: Sending p12 file to data-l1
       copy:
-        src: ../../../source/p12-files/{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}
+        src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/data-l1
 
 - name: Send p12 files to remote node-3
   hosts: node-3
-  become: true
+  gather_facts: false
   tasks:
     - name: Sending p12 file to metagraph-l0
       copy:
-        src: ../../../source/p12-files/{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}
+        src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/metagraph-l0
         
     - name: Sending p12 file to currency-l1
       copy:
-        src: ../../../source/p12-files/{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}
+        src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/currency-l1
 
     - name: Sending p12 file to data-l1
       copy:
-        src: ../../../source/p12-files/{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}
+        src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/data-l1

--- a/infra/ansible/playbooks/deploy/deploy.ansible.yml
+++ b/infra/ansible/playbooks/deploy/deploy.ansible.yml
@@ -1,44 +1,35 @@
 ---
-- import_playbook: configure.ansible.yml
-
 - name: Create directories on remote hosts
   hosts: nodes
   gather_facts: false
   tasks:
-    - name: Create global-l0 directory
-      file:
-        path: /home/{{ ansible_user }}/code/global-l0
-        state: directory
-
     - name: Create metagraph-l0 directory
       file:
         path: /home/{{ ansible_user }}/code/metagraph-l0
         state: directory
+      async: 300
+      poll: 0
 
     - name: Create currency-l1 directory
       file:
         path: /home/{{ ansible_user }}/code/currency-l1
         state: directory
+      async: 300
+      poll: 0
+      when: deploy_cl1 | bool
 
     - name: Create data-l1 directory
       file:
         path: /home/{{ ansible_user }}/code/data-l1
         state: directory
+      async: 300
+      poll: 0
+      when: deploy_dl1 | bool
 
 - name: Send JARs to remote hosts
   hosts: nodes
   gather_facts: false
   tasks:
-    - name: Sending cl-keytool.jar to global-l0
-      copy:
-        src: ../../../docker/shared/jars/cl-keytool.jar
-        dest: /home/{{ ansible_user }}/code/global-l0
-
-    - name: Sending cl-wallet.jar to global-l0
-      copy:
-        src: ../../../docker/shared/jars/cl-wallet.jar
-        dest: /home/{{ ansible_user }}/code/global-l0
-
     - name: Sending cl-keytool.jar to metagraph-l0
       copy:
         src: ../../../docker/shared/jars/cl-keytool.jar
@@ -58,31 +49,37 @@
       copy:
         src: ../../../docker/shared/jars/cl-keytool.jar
         dest: /home/{{ ansible_user }}/code/currency-l1
+      when: deploy_cl1 | bool
     
     - name: Sending cl-wallet.jar to currency-l1
       copy:
         src: ../../../docker/shared/jars/cl-wallet.jar
         dest: /home/{{ ansible_user }}/code/currency-l1
+      when: deploy_cl1 | bool
 
     - name: Sending metagraph-l1-currency.jar to currency-l1
       copy:
         src: ../../../docker/shared/jars/metagraph-l1-currency.jar
         dest: /home/{{ ansible_user }}/code/currency-l1/currency-l1.jar
+      when: deploy_cl1 | bool
 
     - name: Sending cl-keytool.jar to data-l1
       copy:
         src: ../../../docker/shared/jars/cl-keytool.jar
         dest: /home/{{ ansible_user }}/code/data-l1
+      when: deploy_dl1 | bool
 
     - name: Sending cl-wallet.jar to data-l1
       copy:
         src: ../../../docker/shared/jars/cl-wallet.jar
         dest: /home/{{ ansible_user }}/code/data-l1
+      when: deploy_dl1 | bool
 
     - name: Sending metagraph-l1-data.jar to data-l1
       copy:
         src: ../../../docker/shared/jars/metagraph-l1-data.jar
         dest: /home/{{ ansible_user }}/code/data-l1/data-l1.jar
+      when: deploy_dl1 | bool
 
 - name: Send genesis information to remote hosts
   hosts: nodes
@@ -116,11 +113,13 @@
       copy:
         src: ../../../../source/p12-files/{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/currency-l1
+      when: deploy_cl1 | bool
 
     - name: Sending p12 file to data-l1
       copy:
         src: ../../../../source/p12-files/{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/data-l1
+      when: deploy_dl1 | bool
 
 - name: Send p12 files to remote node-2
   hosts: node-2
@@ -135,11 +134,13 @@
       copy:
         src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/currency-l1
+      when: deploy_cl1 | bool
 
     - name: Sending p12 file to data-l1
       copy:
         src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/data-l1
+      when: deploy_dl1 | bool
 
 - name: Send p12 files to remote node-3
   hosts: node-3
@@ -154,8 +155,10 @@
       copy:
         src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/currency-l1
+      when: deploy_cl1 | bool
 
     - name: Sending p12 file to data-l1
       copy:
         src: ../../../../source/p12-files/{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}
         dest: /home/{{ ansible_user }}/code/data-l1
+      when: deploy_dl1 | bool

--- a/infra/ansible/playbooks/start/clean.ansible.yml
+++ b/infra/ansible/playbooks/start/clean.ansible.yml
@@ -16,15 +16,15 @@
     ignore_errors: true
     when: l0_process_id.stdout is defined
 
-  - name: Ensure metagraph-l0 older-logs directory exists
+  - name: Ensure metagraph-l0 archived-logs directory exists
     ansible.builtin.file:
-      path: /home/{{ ansible_user }}/code/metagraph-l0/older-logs
+      path: /home/{{ ansible_user }}/code/metagraph-l0/archived-logs
       state: directory
 
   - name: Save metagraph-l0 current logs
     shell: |
       cd "/home/{{ ansible_user }}/code/metagraph-l0"
-      mv logs older-logs/logs_{{ current_time }}
+      mv logs archived-logs/logs_{{ current_time }}
     ignore_errors: true
     when: l0_process_id.stdout is defined
 
@@ -40,15 +40,15 @@
     ignore_errors: true
     when: cl1_process_id.stdout is defined
 
-  - name: Ensure currency-l1 older-logs directory exists
+  - name: Ensure currency-l1 archived-logs directory exists
     ansible.builtin.file:
-      path: /home/{{ ansible_user }}/code/currency-l1/older-logs
+      path: /home/{{ ansible_user }}/code/currency-l1/archived-logs
       state: directory
 
   - name: Save currency-l1 current logs
     shell: |
       cd "/home/{{ ansible_user }}/code/currency-l1"
-      mv logs older-logs/logs_{{ current_time }}
+      mv logs archived-logs/logs_{{ current_time }}
     ignore_errors: true
     when: cl1_process_id.stdout is defined
 
@@ -64,14 +64,14 @@
     ignore_errors: true
     when: dl1_process_id.stdout is defined
 
-  - name: Ensure data-l1 older-logs directory exists
+  - name: Ensure data-l1 archived-logs directory exists
     ansible.builtin.file:
-      path: /home/{{ ansible_user }}/code/data-l1/older-logs
+      path: /home/{{ ansible_user }}/code/data-l1/archived-logs
       state: directory
 
   - name: Save data-l1 current logs
     shell: |
       cd "/home/{{ ansible_user }}/code/data-l1"
-      mv logs older-logs/logs_{{ current_time }}
+      mv logs archived-logs/logs_{{ current_time }}
     ignore_errors: true
     when: dl1_process_id.stdout is defined

--- a/infra/ansible/playbooks/start/clean.ansible.yml
+++ b/infra/ansible/playbooks/start/clean.ansible.yml
@@ -1,0 +1,77 @@
+- name: Kill current processes
+  hosts: nodes
+  gather_facts: false
+  tasks:
+  - name: Get current timestamp
+    set_fact:
+      current_time: "{{ lookup('pipe', 'date +%Y-%m-%dT%H:%M:%S%z') }}"
+
+  - name: Find metagraph-l0 process ID by port
+    shell: "lsof -t -i:{{ metagraph_l0_public_port }}"
+    register: l0_process_id
+    ignore_errors: true
+
+  - name: Kill metagraph-l0 process
+    shell: "kill -9 {{ l0_process_id.stdout }}"
+    ignore_errors: true
+    when: l0_process_id.stdout is defined
+
+  - name: Ensure metagraph-l0 older-logs directory exists
+    ansible.builtin.file:
+      path: /home/{{ ansible_user }}/code/metagraph-l0/older-logs
+      state: directory
+
+  - name: Save metagraph-l0 current logs
+    shell: |
+      cd "/home/{{ ansible_user }}/code/metagraph-l0"
+      mv logs older-logs/logs_{{ current_time }}
+    ignore_errors: true
+    when: l0_process_id.stdout is defined
+
+
+
+  - name: Find currency-l1 process ID by port
+    shell: "lsof -t -i:{{ currency_l1_public_port }}"
+    register: cl1_process_id
+    ignore_errors: true
+
+  - name: Kill currency-l1 process
+    shell: "kill -9 {{ cl1_process_id.stdout }}"
+    ignore_errors: true
+    when: cl1_process_id.stdout is defined
+
+  - name: Ensure currency-l1 older-logs directory exists
+    ansible.builtin.file:
+      path: /home/{{ ansible_user }}/code/currency-l1/older-logs
+      state: directory
+
+  - name: Save currency-l1 current logs
+    shell: |
+      cd "/home/{{ ansible_user }}/code/currency-l1"
+      mv logs older-logs/logs_{{ current_time }}
+    ignore_errors: true
+    when: cl1_process_id.stdout is defined
+
+
+
+  - name: Find data-l1 process ID by port
+    shell: "lsof -t -i:{{ data_l1_public_port }}"
+    register: dl1_process_id
+    ignore_errors: true
+
+  - name: Kill data-l1 process
+    shell: "kill -9 {{ dl1_process_id.stdout }}"
+    ignore_errors: true
+    when: dl1_process_id.stdout is defined
+
+  - name: Ensure data-l1 older-logs directory exists
+    ansible.builtin.file:
+      path: /home/{{ ansible_user }}/code/data-l1/older-logs
+      state: directory
+
+  - name: Save data-l1 current logs
+    shell: |
+      cd "/home/{{ ansible_user }}/code/data-l1"
+      mv logs older-logs/logs_{{ current_time }}
+    ignore_errors: true
+    when: dl1_process_id.stdout is defined

--- a/infra/ansible/playbooks/start/currency-l1/cluster.ansible.yml
+++ b/infra/ansible/playbooks/start/currency-l1/cluster.ansible.yml
@@ -1,0 +1,98 @@
+---
+- name: Start currency-l1 initial validator
+  hosts: node-1
+  gather_facts: false
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ currency_l1_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ currency_l1_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ currency_l1_cli_port }}"
+
+    CL_L0_PEER_ID: "{{ ml0_node_1_id }}"
+    CL_L0_PEER_HTTP_HOST: "{{ ml0_node_1_ip }}"
+    CL_L0_PEER_HTTP_PORT: "{{ metagraph_l0_public_port }}"
+
+    CL_GLOBAL_L0_PEER_ID: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_ID') }}"
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_IP') }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_PUBLIC_PORT') }}"
+
+    CL_KEYSTORE: "{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_GENESIS_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_GENESIS_FILE_PASSWORD') }}"
+    
+    CL_APP_ENV: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+    CL_COLLATERAL: 0
+    CL_L0_TOKEN_IDENTIFIER: "{{ lookup('env', 'METAGRAPH_ID') }}"
+  tasks:
+    - name: Starting currency-l1 initial validator
+      include_tasks: initial_validator.ansible.yml
+
+    - name: Get node_id
+      shell: |
+        cd /home/{{ ansible_user }}/code/currency-l1
+        java -jar cl-wallet.jar show-id
+      register: node_id
+      ignore_errors: yes 
+
+    - set_fact:
+        cl1_node_1_ip: "{{ ansible_host }}"
+        cl1_node_1_id: "{{ node_id.stdout }}"
+
+- name: Start currency-l1 validator 1
+  hosts: node-2
+  gather_facts: false
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ currency_l1_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ currency_l1_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ currency_l1_cli_port }}"
+
+    CL_L0_PEER_ID: "{{ ml0_node_1_id }}"
+    CL_L0_PEER_HTTP_HOST: "{{ ml0_node_1_ip }}"
+    CL_L0_PEER_HTTP_PORT: "{{ metagraph_l0_public_port }}"
+
+    CL_GLOBAL_L0_PEER_ID: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_ID') }}"
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_IP') }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_PUBLIC_PORT') }}"
+
+    CL_KEYSTORE: "{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_NODE_2_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_NODE_2_FILE_PASSWORD') }}"
+
+    CL_APP_ENV: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+    CL_COLLATERAL: 0
+    CL_L0_TOKEN_IDENTIFIER: "{{ lookup('env', 'METAGRAPH_ID') }}"
+  tasks:
+    - name: Starting currency-l1 validator 1 node
+      include_tasks: validator.ansible.yml
+      vars:
+        currency_L1_GENESIS_NODE_ID: "{{ hostvars['node-1']['cl1_node_1_id'] }}"
+        currency_L1_GENESIS_NODE_IP: "{{ hostvars['node-1']['cl1_node_1_ip'] }}"
+
+- name: Start currency-l1 validator 2
+  hosts: node-3
+  gather_facts: false
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ currency_l1_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ currency_l1_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ currency_l1_cli_port }}"
+
+    CL_L0_PEER_ID: "{{ ml0_node_1_id }}"
+    CL_L0_PEER_HTTP_HOST: "{{ ml0_node_1_ip }}"
+    CL_L0_PEER_HTTP_PORT: "{{ metagraph_l0_public_port }}"
+
+    CL_GLOBAL_L0_PEER_ID: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_ID') }}"
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_IP') }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_PUBLIC_PORT') }}"
+
+    CL_KEYSTORE: "{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_NODE_3_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_NODE_3_FILE_PASSWORD') }}"
+
+    CL_APP_ENV: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+    CL_COLLATERAL: 0
+    CL_L0_TOKEN_IDENTIFIER: "{{ lookup('env', 'METAGRAPH_ID') }}"
+  tasks:
+    - name: Starting currency-l1 validator 1 node
+      include_tasks: validator.ansible.yml
+      vars:
+        currency_L1_GENESIS_NODE_ID: "{{ hostvars['node-1']['cl1_node_1_id'] }}"
+        currency_L1_GENESIS_NODE_IP: "{{ hostvars['node-1']['cl1_node_1_ip'] }}"

--- a/infra/ansible/playbooks/start/currency-l1/initial_validator.ansible.yml
+++ b/infra/ansible/playbooks/start/currency-l1/initial_validator.ansible.yml
@@ -1,0 +1,41 @@
+---
+- name: Check if currency-l1.jar exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/currency-l1/currency-l1.jar"
+  register: currency_l1_jar
+
+- name: Display message if file currency-l1.jar doesn't exist
+  debug:
+    msg: "File /home/{{ ansible_user }}/code/currency-l1/currency-l1.jar does not exist"
+  when: not currency_l1_jar.stat.exists
+
+- name: Skip remaining tasks if file currency-l1.jar doesn't exist
+  meta: end_play
+  when: not currency_l1_jar.stat.exists
+     
+- name: Check if token file exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/currency-l1/{{ lookup('env', 'CL_KEYSTORE') }}"
+  register: token_file
+
+- name: Throw an error if the token_file doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/currency-l1/{{ lookup('env', 'CL_KEYSTORE') }} does not exist"
+  when: not token_file.stat.exists
+
+- name: Start as initial validator
+  shell: |
+    cd "/home/{{ ansible_user }}/code/currency-l1"
+    nohup java -jar currency-l1.jar run-initial-validator --ip {{ ansible_host }} > currency-l1.log 2>&1 &
+
+- name: Check if node is Ready
+  uri:
+    url: "http://localhost:{{ currency_l1_public_port }}/node/info"
+    method: GET
+    return_content: yes
+  register: response
+  until: response.status == 200 and ("Ready" in response.content | string or retries >= 100)
+  retries: 120
+  delay: 1
+  vars:
+    retries: 0

--- a/infra/ansible/playbooks/start/currency-l1/validator.ansible.yml
+++ b/infra/ansible/playbooks/start/currency-l1/validator.ansible.yml
@@ -1,0 +1,60 @@
+---
+- name: Check if currency-l1.jar exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/currency-l1/currency-l1.jar"
+  register: currency_l1_jar
+
+- name: Display message if file currency-l1.jar doesn't exist
+  debug:
+    msg: "File /home/{{ ansible_user }}/code/currency-l1/currency-l1.jar does not exist"
+  when: not currency_l1_jar.stat.exists
+
+- name: Skip remaining tasks if file currency-l1.jar doesn't exist
+  meta: end_play
+  when: not currency_l1_jar.stat.exists
+     
+- name: Check if token file exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/currency-l1/{{ lookup('env', 'CL_KEYSTORE') }}"
+  register: token_file
+
+- name: Throw an error if the token_file doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/currency-l1/{{ lookup('env', 'CL_KEYSTORE') }} does not exist"
+  when: not token_file.stat.exists
+
+- name: Start as validator
+  shell: |
+    cd "/home/{{ ansible_user }}/code/currency-l1"
+    nohup java -jar currency-l1.jar run-validator --ip {{ ansible_host }} > currency-l1.log 2>&1 &
+
+- name: Check if node is ReadyToJoin
+  uri:
+    url: "http://localhost:{{ currency_l1_public_port }}/node/info"
+    method: GET
+    return_content: yes
+  register: response
+  until: response.status == 200 and ("ReadyToJoin" in response.content | string or retries >= 100)
+  retries: 120
+  delay: 1
+  vars:
+    retries: 0
+
+- name: Join Cluster
+  uri:
+    url: "http://localhost:{{ currency_l1_cli_port }}/cluster/join"
+    method: POST
+    headers:
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      id: "{{ currency_L1_GENESIS_NODE_ID }}"
+      ip: "{{ currency_L1_GENESIS_NODE_IP }}"
+      p2pPort: "{{ currency_l1_p2p_port }}"
+    return_content: yes
+  register: curl_output
+  until: (curl_output.status == 200 or curl_output.status == 404) or retries >= 5
+  retries: 5
+  delay: 10
+  vars:
+    retries: 0

--- a/infra/ansible/playbooks/start/data-l1/cluster.ansible.yml
+++ b/infra/ansible/playbooks/start/data-l1/cluster.ansible.yml
@@ -1,0 +1,98 @@
+---
+- name: Start data-l1 initial validator
+  hosts: node-1
+  gather_facts: false
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ data_l1_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ data_l1_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ data_l1_cli_port }}"
+
+    CL_L0_PEER_ID: "{{ ml0_node_1_id }}"
+    CL_L0_PEER_HTTP_HOST: "{{ ml0_node_1_ip }}"
+    CL_L0_PEER_HTTP_PORT: "{{ metagraph_l0_public_port }}"
+
+    CL_GLOBAL_L0_PEER_ID: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_ID') }}"
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_IP') }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_PUBLIC_PORT') }}"
+
+    CL_KEYSTORE: "{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_GENESIS_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_GENESIS_FILE_PASSWORD') }}"
+    
+    CL_APP_ENV: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+    CL_COLLATERAL: 0
+    CL_L0_TOKEN_IDENTIFIER: "{{ lookup('env', 'METAGRAPH_ID') }}"
+  tasks:
+    - name: Starting data-l1 initial validator
+      include_tasks: initial_validator.ansible.yml
+
+    - name: Get node_id
+      shell: |
+        cd /home/{{ ansible_user }}/code/data-l1
+        java -jar cl-wallet.jar show-id
+      register: node_id
+      ignore_errors: yes 
+
+    - set_fact:
+        dl1_node_1_ip: "{{ ansible_host }}"
+        dl1_node_1_id: "{{ node_id.stdout }}"
+
+- name: Start data-l1 validator 1
+  hosts: node-2
+  gather_facts: false
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ data_l1_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ data_l1_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ data_l1_cli_port }}"
+
+    CL_L0_PEER_ID: "{{ ml0_node_1_id }}"
+    CL_L0_PEER_HTTP_HOST: "{{ ml0_node_1_ip }}"
+    CL_L0_PEER_HTTP_PORT: "{{ metagraph_l0_public_port }}"
+
+    CL_GLOBAL_L0_PEER_ID: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_ID') }}"
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_IP') }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_PUBLIC_PORT') }}"
+
+    CL_KEYSTORE: "{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_NODE_2_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_NODE_2_FILE_PASSWORD') }}"
+
+    CL_APP_ENV: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+    CL_COLLATERAL: 0
+    CL_L0_TOKEN_IDENTIFIER: "{{ lookup('env', 'METAGRAPH_ID') }}"
+  tasks:
+    - name: Starting data-l1 validator 1 node
+      include_tasks: validator.ansible.yml
+      vars:
+        DATA_L1_GENESIS_NODE_ID: "{{ hostvars['node-1']['dl1_node_1_id'] }}"
+        DATA_L1_GENESIS_NODE_IP: "{{ hostvars['node-1']['dl1_node_1_ip'] }}"
+
+- name: Start data-l1 validator 2
+  hosts: node-3
+  gather_facts: false
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ data_l1_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ data_l1_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ data_l1_cli_port }}"
+
+    CL_L0_PEER_ID: "{{ ml0_node_1_id }}"
+    CL_L0_PEER_HTTP_HOST: "{{ ml0_node_1_ip }}"
+    CL_L0_PEER_HTTP_PORT: "{{ metagraph_l0_public_port }}"
+
+    CL_GLOBAL_L0_PEER_ID: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_ID') }}"
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_IP') }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_PUBLIC_PORT') }}"
+
+    CL_KEYSTORE: "{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_NODE_3_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_NODE_3_FILE_PASSWORD') }}"
+
+    CL_APP_ENV: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+    CL_COLLATERAL: 0
+    CL_L0_TOKEN_IDENTIFIER: "{{ lookup('env', 'METAGRAPH_ID') }}"
+  tasks:
+    - name: Starting data-l1 validator 1 node
+      include_tasks: validator.ansible.yml
+      vars:
+        DATA_L1_GENESIS_NODE_ID: "{{ hostvars['node-1']['dl1_node_1_id'] }}"
+        DATA_L1_GENESIS_NODE_IP: "{{ hostvars['node-1']['dl1_node_1_ip'] }}"

--- a/infra/ansible/playbooks/start/data-l1/initial_validator.ansible.yml
+++ b/infra/ansible/playbooks/start/data-l1/initial_validator.ansible.yml
@@ -1,0 +1,41 @@
+---
+- name: Check if data-l1.jar exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/data-l1/data-l1.jar"
+  register: data_l1_jar
+
+- name: Display message if file data-l1.jar doesn't exist
+  debug:
+    msg: "File /home/{{ ansible_user }}/code/data-l1/data-l1.jar does not exist"
+  when: not data_l1_jar.stat.exists
+
+- name: Skip remaining tasks if file data-l1.jar doesn't exist
+  meta: end_play
+  when: not data_l1_jar.stat.exists
+     
+- name: Check if token file exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/data-l1/{{ lookup('env', 'CL_KEYSTORE') }}"
+  register: token_file
+
+- name: Throw an error if the token_file doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/data-l1/{{ lookup('env', 'CL_KEYSTORE') }} does not exist"
+  when: not token_file.stat.exists
+
+- name: Start as initial validator
+  shell: |
+    cd "/home/{{ ansible_user }}/code/data-l1"
+    nohup java -jar data-l1.jar run-initial-validator --ip {{ ansible_host }} > data-l1.log 2>&1 &
+
+- name: Check if node is Ready
+  uri:
+    url: "http://localhost:{{ data_l1_public_port }}/node/info"
+    method: GET
+    return_content: yes
+  register: response
+  until: response.status == 200 and ("Ready" in response.content | string or retries >= 100)
+  retries: 120
+  delay: 1
+  vars:
+    retries: 0

--- a/infra/ansible/playbooks/start/data-l1/validator.ansible.yml
+++ b/infra/ansible/playbooks/start/data-l1/validator.ansible.yml
@@ -1,0 +1,60 @@
+---
+- name: Check if data-l1.jar exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/data-l1/data-l1.jar"
+  register: data_l1_jar
+
+- name: Display message if file data-l1.jar doesn't exist
+  debug:
+    msg: "File /home/{{ ansible_user }}/code/data-l1/data-l1.jar does not exist"
+  when: not data_l1_jar.stat.exists
+
+- name: Skip remaining tasks if file data-l1.jar doesn't exist
+  meta: end_play
+  when: not data_l1_jar.stat.exists
+  
+- name: Check if token file exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/data-l1/{{ lookup('env', 'CL_KEYSTORE') }}"
+  register: token_file
+
+- name: Throw an error if the token_file doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/data-l1/{{ lookup('env', 'CL_KEYSTORE') }} does not exist"
+  when: not token_file.stat.exists
+
+- name: Start as validator
+  shell: |
+    cd "/home/{{ ansible_user }}/code/data-l1"
+    nohup java -jar data-l1.jar run-validator --ip {{ ansible_host }} > data-l1.log 2>&1 &
+
+- name: Check if node is ReadyToJoin
+  uri:
+    url: "http://localhost:{{ data_l1_public_port }}/node/info"
+    method: GET
+    return_content: yes
+  register: response
+  until: response.status == 200 and ("ReadyToJoin" in response.content | string or retries >= 100)
+  retries: 120
+  delay: 1
+  vars:
+    retries: 0
+
+- name: Join Cluster
+  uri:
+    url: "http://localhost:{{ data_l1_cli_port }}/cluster/join"
+    method: POST
+    headers:
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      id: "{{ DATA_L1_GENESIS_NODE_ID }}"
+      ip: "{{ DATA_L1_GENESIS_NODE_IP }}"
+      p2pPort: "{{ data_l1_p2p_port }}"
+    return_content: yes
+  register: curl_output
+  until: (curl_output.status == 200 or curl_output.status == 404) or retries >= 5
+  retries: 5
+  delay: 10
+  vars:
+    retries: 0

--- a/infra/ansible/playbooks/start/metagraph-l0/cluster.ansible.yml
+++ b/infra/ansible/playbooks/start/metagraph-l0/cluster.ansible.yml
@@ -1,0 +1,94 @@
+---
+- name: Start metagraph-l0 genesis
+  hosts: node-1
+  gather_facts: false
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ metagraph_l0_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ metagraph_l0_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ metagraph_l0_cli_port }}"
+
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_IP') }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_PUBLIC_PORT') }}"
+    CL_GLOBAL_L0_PEER_ID: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_ID') }}"
+
+    CL_KEYSTORE: "{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_GENESIS_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_GENESIS_FILE_PASSWORD') }}"
+    
+    CL_APP_ENV: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+    CL_COLLATERAL: 0
+    CL_L0_TOKEN_IDENTIFIER: "{{ lookup('env', 'METAGRAPH_ID') }}"
+  tasks:
+    - name: Starting metagraph-l0 genesis node
+      include_tasks: genesis.ansible.yml
+      vars:
+        force_genesis: "{{ force_genesis }}"
+
+    - name: Get node_id
+      shell: |
+        cd /home/{{ ansible_user }}/code/metagraph-l0
+        java -jar cl-wallet.jar show-id
+      register: node_id
+      ignore_errors: yes 
+
+    - name: Get node_ip
+      uri:
+        url: "https://ifconfig.me/ip"
+        return_content: yes
+      register: ip_address_result
+
+    - set_fact:
+        ml0_node_1_ip: "{{ ip_address_result.content }}"
+        ml0_node_1_id: "{{ node_id.stdout }}"
+
+- name: Start metagraph-l0 validator 1
+  hosts: node-2
+  gather_facts: false
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ metagraph_l0_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ metagraph_l0_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ metagraph_l0_cli_port }}"
+
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_IP') }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_PUBLIC_PORT') }}"
+    CL_GLOBAL_L0_PEER_ID: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_ID') }}"
+
+    CL_KEYSTORE: "{{ lookup('env', 'P12_NODE_2_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_NODE_2_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_NODE_2_FILE_PASSWORD') }}"
+
+    CL_APP_ENV: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+    CL_COLLATERAL: 0
+    CL_L0_TOKEN_IDENTIFIER: "{{ lookup('env', 'METAGRAPH_ID') }}"
+  tasks:
+    - name: Starting metagraph-l0 validator 1 node
+      include_tasks: validator.ansible.yml
+      vars:
+        METAGRAPH_L0_GENESIS_NODE_ID: "{{ hostvars['node-1']['ml0_node_1_id'] }}"
+        METAGRAPH_L0_GENESIS_NODE_IP: "{{ hostvars['node-1']['ml0_node_1_ip'] }}"
+
+- name: Start metagraph-l0 validator 2
+  hosts: node-3
+  gather_facts: false
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ metagraph_l0_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ metagraph_l0_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ metagraph_l0_cli_port }}"
+
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_IP') }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_PUBLIC_PORT') }}"
+    CL_GLOBAL_L0_PEER_ID: "{{ lookup('env', 'DEPLOY_NETWORK_HOST_ID') }}"
+
+    CL_KEYSTORE: "{{ lookup('env', 'P12_NODE_3_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_NODE_3_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_NODE_3_FILE_PASSWORD') }}"
+    
+    CL_APP_ENV: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+    CL_COLLATERAL: 0
+    CL_L0_TOKEN_IDENTIFIER: "{{ lookup('env', 'METAGRAPH_ID') }}"
+  tasks:
+    - name: Starting metagraph-l0 validator 1 node
+      include_tasks: validator.ansible.yml
+      vars:
+        METAGRAPH_L0_GENESIS_NODE_ID: "{{ hostvars['node-1']['ml0_node_1_id'] }}"
+        METAGRAPH_L0_GENESIS_NODE_IP: "{{ hostvars['node-1']['ml0_node_1_ip'] }}"

--- a/infra/ansible/playbooks/start/metagraph-l0/genesis.ansible.yml
+++ b/infra/ansible/playbooks/start/metagraph-l0/genesis.ansible.yml
@@ -4,16 +4,16 @@
     current_time: "{{ lookup('pipe', 'date +%Y-%m-%dT%H:%M:%S%z') }}"
   when: force_genesis | bool
 
-- name: Ensure older-datas directory exists
+- name: Ensure archived-data directory exists
   ansible.builtin.file:
-    path: /home/{{ ansible_user }}/code/metagraph-l0/older-datas
+    path: /home/{{ ansible_user }}/code/metagraph-l0/archived-data
     state: directory
   when: force_genesis | bool
 
 - name: Save previous data directory
   shell: |
     cd "/home/{{ ansible_user }}/code/metagraph-l0"
-    mv data older-datas/data_{{ current_time }}
+    mv data archived-data/data_{{ current_time }}
   ignore_errors: true
   when: force_genesis | bool
 

--- a/infra/ansible/playbooks/start/metagraph-l0/genesis.ansible.yml
+++ b/infra/ansible/playbooks/start/metagraph-l0/genesis.ansible.yml
@@ -1,0 +1,67 @@
+---
+- name: Get current timestamp
+  set_fact:
+    current_time: "{{ lookup('pipe', 'date +%Y-%m-%dT%H:%M:%S%z') }}"
+  when: force_genesis | bool
+
+- name: Ensure older-datas directory exists
+  ansible.builtin.file:
+    path: /home/{{ ansible_user }}/code/metagraph-l0/older-datas
+    state: directory
+  when: force_genesis | bool
+
+- name: Save previous data directory
+  shell: |
+    cd "/home/{{ ansible_user }}/code/metagraph-l0"
+    mv data older-datas/data_{{ current_time }}
+  ignore_errors: true
+  when: force_genesis | bool
+
+- name: Check if metagraph-l0.jar exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/metagraph-l0/metagraph-l0.jar"
+  register: metagraph_l0_jar
+
+- name: Throw an error if the file metagraph-l0.jar doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/metagraph-l0/metagraph-l0.jar does not exist"
+  when: not metagraph_l0_jar.stat.exists
+     
+- name: Check if token file exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/metagraph-l0/{{ lookup('env', 'CL_KEYSTORE') }}"
+  register: token_file
+
+- name: Throw an error if the token_file doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/metagraph-l0/{{ lookup('env', 'CL_KEYSTORE') }} does not exist"
+  when: not token_file.stat.exists
+
+- name: Check if we already have incremental snapshots
+  stat:
+    path: "/home/{{ ansible_user }}/code/metagraph-l0/data/incremental_snapshot"
+  register: folder_exists
+
+- name: Start as rollback
+  shell: |
+    cd "/home/{{ ansible_user }}/code/metagraph-l0"
+    nohup java -jar metagraph-l0.jar run-rollback --ip {{ ansible_host }} > metagraph-l0.log 2>&1 &
+  when: folder_exists.stat.exists and not force_genesis | default(false)
+
+- name: Start as genesis
+  shell: |
+    cd /home/{{ ansible_user }}/code/metagraph-l0
+    nohup java -jar metagraph-l0.jar run-genesis genesis.snapshot --ip {{ ansible_host }} > metagraph-l0.log 2>&1 &
+  when: not folder_exists.stat.exists or force_genesis | default(false)
+
+- name: Check if node is Ready
+  uri:
+    url: "http://localhost:{{ metagraph_l0_public_port }}/node/info"
+    method: GET
+    return_content: yes
+  register: response
+  until: response.status == 200 and ("Ready" in response.content | string or retries >= 100)
+  retries: 120
+  delay: 1
+  vars:
+    retries: 0

--- a/infra/ansible/playbooks/start/metagraph-l0/validator.ansible.yml
+++ b/infra/ansible/playbooks/start/metagraph-l0/validator.ansible.yml
@@ -1,0 +1,56 @@
+---
+- name: Check if metagraph-l0.jar exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/metagraph-l0/metagraph-l0.jar"
+  register: metagraph_l0_jar
+
+- name: Throw an error if the file metagraph-l0.jar doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/metagraph-l0/metagraph-l0.jar does not exist"
+  when: not metagraph_l0_jar.stat.exists
+     
+- name: Check if token file exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/metagraph-l0/{{ lookup('env', 'CL_KEYSTORE') }}"
+  register: token_file
+
+- name: Throw an error if the token_file doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/metagraph-l0/{{ lookup('env', 'CL_KEYSTORE') }} does not exist"
+  when: not token_file.stat.exists
+
+- name: Start as validator
+  shell: |
+    cd "/home/{{ ansible_user }}/code/metagraph-l0"
+    nohup java -jar metagraph-l0.jar run-validator --ip {{ ansible_host }} > metagraph-l0.log 2>&1 &
+
+- name: Check if node is ReadyToJoin
+  uri:
+    url: "http://localhost:{{ metagraph_l0_public_port }}/node/info"
+    method: GET
+    return_content: yes
+  register: response
+  until: response.status == 200 and ("ReadyToJoin" in response.content | string or retries >= 100)
+  retries: 120
+  delay: 1
+  vars:
+    retries: 0
+
+- name: Join Cluster
+  uri:
+    url: "http://localhost:{{ metagraph_l0_cli_port }}/cluster/join"
+    method: POST
+    headers:
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      id: "{{ METAGRAPH_L0_GENESIS_NODE_ID }}"
+      ip: "{{ METAGRAPH_L0_GENESIS_NODE_IP }}"
+      p2pPort: "{{ metagraph_l0_p2p_port }}"
+    return_content: yes
+  register: curl_output
+  until: (curl_output.status == 200 or curl_output.status == 404) or retries >= 5
+  retries: 5
+  delay: 10
+  vars:
+    retries: 0

--- a/infra/ansible/playbooks/start/start.ansible.yml
+++ b/infra/ansible/playbooks/start/start.ansible.yml
@@ -1,0 +1,35 @@
+---
+- import_playbook: clean.ansible.yml
+
+- import_playbook: metagraph-l0/cluster.ansible.yml
+  vars:
+    force_genesis: "{{ force_genesis }}"
+
+- name: Get metagraph L0 node info
+  gather_facts: false
+  hosts: node-1
+  environment:
+    CL_KEYSTORE: "{{ lookup('env', 'P12_GENESIS_FILE_NAME') }}"
+    CL_KEYALIAS: "{{ lookup('env', 'P12_GENESIS_FILE_KEY_ALIAS') }}"
+    CL_PASSWORD: "{{ lookup('env', 'P12_GENESIS_FILE_PASSWORD') }}"
+  tasks:
+    - name: Get node_id
+      shell: |
+        cd /home/{{ ansible_user }}/code/metagraph-l0
+        java -jar cl-wallet.jar show-id
+      register: node_id
+      ignore_errors: yes 
+
+    - set_fact:
+        ml0_node_1_ip: "{{ ansible_host }}"
+        ml0_node_1_id: "{{ node_id.stdout }}"
+
+- import_playbook: currency-l1/cluster.ansible.yml
+  vars:
+    ml0_node_1_id: "{{ hostvars['node-1']['ml0_node_1_id'] }}"
+    ml0_node_1_ip: "{{ hostvars['node-1']['ml0_node_1_ip'] }}"
+
+- import_playbook: data-l1/cluster.ansible.yml
+  vars:
+    ml0_node_1_id: "{{ hostvars['node-1']['ml0_node_1_id'] }}"
+    ml0_node_1_ip: "{{ hostvars['node-1']['ml0_node_1_ip'] }}"

--- a/infra/docker/dag-l1/initial-validator/Dockerfile
+++ b/infra/docker/dag-l1/initial-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS

--- a/infra/docker/dag-l1/node-2/Dockerfile
+++ b/infra/docker/dag-l1/node-2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS

--- a/infra/docker/dag-l1/node-3/Dockerfile
+++ b/infra/docker/dag-l1/node-3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS

--- a/infra/docker/global-l0/Dockerfile
+++ b/infra/docker/global-l0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME

--- a/infra/docker/metagraph-l0-genesis/Dockerfile
+++ b/infra/docker/metagraph-l0-genesis/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS
@@ -19,7 +19,7 @@ COPY project/$TEMPLATE_NAME codebase/$TEMPLATE_NAME
 COPY p12-files/${P12_FILE_NAME_GENESIS} ${P12_FILE_NAME_GENESIS}
 
 RUN cd codebase/$TEMPLATE_NAME  && \
-    sbt --error currencyL0/assembly
+    sbt currencyL0/assembly
 
 RUN mv codebase/$TEMPLATE_NAME/modules/l0/target/scala-2.13/${TEMPLATE_NAME}-currency-l0-assembly-* metagraph-l0.jar
 RUN touch start_genesis_metagraph.sh

--- a/infra/docker/metagraph-l0/node-2/Dockerfile
+++ b/infra/docker/metagraph-l0/node-2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS

--- a/infra/docker/metagraph-l0/node-3/Dockerfile
+++ b/infra/docker/metagraph-l0/node-3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS

--- a/infra/docker/metagraph-l1-currency/initial-validator/Dockerfile
+++ b/infra/docker/metagraph-l1-currency/initial-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS
@@ -19,6 +19,6 @@ COPY project/$TEMPLATE_NAME codebase/$TEMPLATE_NAME
 COPY p12-files/${P12_FILE_NAME_GENESIS} ${P12_FILE_NAME_GENESIS}
 
 RUN cd codebase/$TEMPLATE_NAME && \
-    sbt --error currencyL1/assembly
+    sbt currencyL1/assembly
 
 RUN mv codebase/$TEMPLATE_NAME/modules/l1/target/scala-2.13/${TEMPLATE_NAME}-currency-l1-assembly-* metagraph-l1-currency.jar

--- a/infra/docker/metagraph-l1-currency/node-2/Dockerfile
+++ b/infra/docker/metagraph-l1-currency/node-2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS

--- a/infra/docker/metagraph-l1-currency/node-3/Dockerfile
+++ b/infra/docker/metagraph-l1-currency/node-3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS

--- a/infra/docker/metagraph-l1-data/initial-validator/Dockerfile
+++ b/infra/docker/metagraph-l1-data/initial-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS
@@ -19,6 +19,6 @@ COPY project/$TEMPLATE_NAME codebase/$TEMPLATE_NAME
 COPY p12-files/${P12_FILE_NAME_GENESIS} ${P12_FILE_NAME_GENESIS}
 
 RUN cd codebase/$TEMPLATE_NAME && \
-    sbt --error dataL1/assembly
+    sbt dataL1/assembly
 
 RUN mv codebase/$TEMPLATE_NAME/modules/data_l1/target/scala-2.13/${TEMPLATE_NAME}-data_l1-assembly-* metagraph-l1-data.jar

--- a/infra/docker/metagraph-l1-data/node-2/Dockerfile
+++ b/infra/docker/metagraph-l1-data/node-2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS

--- a/infra/docker/metagraph-l1-data/node-3/Dockerfile
+++ b/infra/docker/metagraph-l1-data/node-3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-with-java-and-sbt
+FROM --platform=linux/amd64 ubuntu-with-java-and-sbt
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG P12_FILE_NAME_GENESIS

--- a/infra/docker/ubuntu-with-java-and-sbt/Dockerfile
+++ b/infra/docker/ubuntu-with-java-and-sbt/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
 
 WORKDIR "/code"
 

--- a/scripts/hydra
+++ b/scripts/hydra
@@ -357,7 +357,19 @@ function remote_deploy() {
   
   echo_yellow "Deploying on remote hosts"
   echo_white ""
-  ansible-playbook -i $ANSIBLE_HOSTS_FILE $ANSIBLE_DEPLOY_PLAYBOOK_FILE
+  if [[ " ${DOCKER_CONTAINERS[@]} " =~ "metagraph-l1-currency" ]]; then
+    deploy_cl1=true
+  else
+    deploy_cl1=false
+  fi
+
+  if [[ " ${DOCKER_CONTAINERS[@]} " =~ "metagraph-l1-data" ]]; then
+    deploy_dl1=true
+  else
+    deploy_dl1=false
+  fi
+  
+  ansible-playbook -e "deploy_cl1=$deploy_cl1" -e "deploy_dl1=$deploy_dl1" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_DEPLOY_PLAYBOOK_FILE
 }
 
 # @cmd Remotely start the metagraph on cloud instances using Ansible
@@ -373,9 +385,11 @@ function remote_start() {
   echo_yellow "Starting on remote hosts"
   echo_white ""
   if [ ! -z "$argc_force_genesis" ]; then
-    ansible-playbook -e "force_genesis=true" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_START_PLAYBOOK_FILE
+    force_genesis=true
   else
-    ansible-playbook -e "force_genesis=false" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_START_PLAYBOOK_FILE
+    force_genesis=false
   fi
+
+  ansible-playbook -e "force_genesis=$force_genesis" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_START_PLAYBOOK_FILE
 }
 eval "$(argc --argc-eval "$0" "$@")"

--- a/scripts/hydra
+++ b/scripts/hydra
@@ -347,19 +347,6 @@ function status() {
   fi
 }
 
-# @cmd Remotely configure cloud instances using Ansible.
-# -> DEFAULT_ANSIBLE_HOSTS_FILE: infra/ansible/hosts.ansible.yml
-# -> DEFAULT_ANSIBLE_CONFIGURE_PLAYBOOK_FILE: infra/ansible/playbooks/configure.ansible.yml
-function remote_configure() {
-  load_scripts
-  ansible_validations
-  cd ..
-  
-  echo_yellow "Configuring dependencies on remote hosts"
-  echo_white ""
-  ansible-playbook -i $ANSIBLE_HOSTS_FILE $ANSIBLE_CONFIGURE_PLAYBOOK_FILE
-}
-
 # @cmd Remotely deploy to cloud instances using Ansible
 # -> DEFAULT_ANSIBLE_HOSTS_FILE: infra/ansible/hosts.ansible.yml
 # -> DEFAULT_ANSIBLE_DEPLOY_PLAYBOOK_FILE: infra/ansible/playbooks/deploy.ansible.yml
@@ -373,4 +360,22 @@ function remote_deploy() {
   ansible-playbook -i $ANSIBLE_HOSTS_FILE $ANSIBLE_DEPLOY_PLAYBOOK_FILE
 }
 
+# @cmd Remotely start the metagraph on cloud instances using Ansible
+# -> DEFAULT_ANSIBLE_HOSTS_FILE: infra/ansible/hosts.ansible.yml
+# -> DEFAULT_ANSIBLE_START_PLAYBOOK_FILE: infra/ansible/playbooks/start/start.ansible.yml
+# @flag   --force_genesis                      Force metagraph to run as genesis
+function remote_start() {
+  load_scripts
+  ansible_validations
+  check_network $DEPLOY_NETWORK_NAME
+  cd ..
+  
+  echo_yellow "Starting on remote hosts"
+  echo_white ""
+  if [ ! -z "$argc_force_genesis" ]; then
+    ansible-playbook -e "force_genesis=true" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_START_PLAYBOOK_FILE
+  else
+    ansible-playbook -e "force_genesis=false" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_START_PLAYBOOK_FILE
+  fi
+}
 eval "$(argc --argc-eval "$0" "$@")"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -195,7 +195,7 @@ function ansible_validations() {
 function check_network() {
     local network="$1"
     case "$network" in
-    "testnet" | "integrationnet" | "mainnet")
+    "integrationnet" | "mainnet")
         echo "Valid network: $network"
         ;;
     *)

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -46,9 +46,16 @@ function fill_env_variables_from_json_config_file() {
     export P12_NODE_3_FILE_KEY_ALIAS=$(jq -r .p12_files.validators[1].alias euclid.json)
     export P12_NODE_3_FILE_PASSWORD=$(jq -r .p12_files.validators[1].password euclid.json)
     export DOCKER_CONTAINERS=$(jq -r .docker.default_containers euclid.json)
-    export ANSIBLE_HOSTS_FILE=$(jq -r .ansible.hosts_file euclid.json)
-    export ANSIBLE_CONFIGURE_PLAYBOOK_FILE=$(jq -r .ansible.configure_playbook_file euclid.json)
-    export ANSIBLE_DEPLOY_PLAYBOOK_FILE=$(jq -r .ansible.deploy_playbook_file euclid.json)
+
+    export DEPLOY_NETWORK_NAME=$(jq -r .deploy.network.name euclid.json)
+    export DEPLOY_NETWORK_HOST_IP=$(jq -r .deploy.network.node.ip euclid.json)
+    export DEPLOY_NETWORK_HOST_ID=$(jq -r .deploy.network.node.id euclid.json)
+    export DEPLOY_NETWORK_HOST_PUBLIC_PORT=$(jq -r .deploy.network.node.public_port euclid.json)
+
+    export ANSIBLE_HOSTS_FILE=$(jq -r .deploy.ansible.hosts euclid.json)
+    export ANSIBLE_CONFIGURE_PLAYBOOK_FILE=$(jq -r .deploy.ansible.playbooks.configure euclid.json)
+    export ANSIBLE_DEPLOY_PLAYBOOK_FILE=$(jq -r .deploy.ansible.playbooks.deploy euclid.json)
+    export ANSIBLE_START_PLAYBOOK_FILE=$(jq -r .deploy.ansible.playbooks.start euclid.json)
 
     ## Colors
     export OUTPUT_RED=$(tput setaf 1)
@@ -181,6 +188,19 @@ function ansible_validations() {
     done <"$ANSIBLE_HOSTS_FILE"
 
     cd scripts
-    
+
     echo_green "Hosts are valid"
+}
+
+function check_network() {
+    local network="$1"
+    case "$network" in
+    "testnet" | "integrationnet" | "mainnet")
+        echo "Valid network: $network"
+        ;;
+    *)
+        echo "Invalid network: $network"
+        exit 1
+        ;;
+    esac
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -48,9 +48,9 @@ function fill_env_variables_from_json_config_file() {
     export DOCKER_CONTAINERS=$(jq -r .docker.default_containers euclid.json)
 
     export DEPLOY_NETWORK_NAME=$(jq -r .deploy.network.name euclid.json)
-    export DEPLOY_NETWORK_HOST_IP=$(jq -r .deploy.network.node.ip euclid.json)
-    export DEPLOY_NETWORK_HOST_ID=$(jq -r .deploy.network.node.id euclid.json)
-    export DEPLOY_NETWORK_HOST_PUBLIC_PORT=$(jq -r .deploy.network.node.public_port euclid.json)
+    export DEPLOY_NETWORK_HOST_IP=$(jq -r .deploy.network.gl0_node.ip euclid.json)
+    export DEPLOY_NETWORK_HOST_ID=$(jq -r .deploy.network.gl0_node.id euclid.json)
+    export DEPLOY_NETWORK_HOST_PUBLIC_PORT=$(jq -r .deploy.network.gl0_node.public_port euclid.json)
 
     export ANSIBLE_HOSTS_FILE=$(jq -r .deploy.ansible.hosts euclid.json)
     export ANSIBLE_CONFIGURE_PLAYBOOK_FILE=$(jq -r .deploy.ansible.playbooks.configure euclid.json)


### PR DESCRIPTION
### Changes
+ Unified `remote_configure` and `remote_deploy` to only `remote_deploy`
+ Updated Dockerfiles to enforce linux/amd64 images to prevent architecture issues during JAR generation.
+ Added the remote_start function for initiating remote metagraph startup.
+ Updated euclid.json file to include new required information necessary for remote metagraph startup.
+ Implemented validation to ensure the provided network is valid.
+ Included playbooks to facilitate remote metagraph startup on cloud instances.
+ Updated README.md