### PR TITLE
Adding nodectl integration

### DIFF
--- a/infra/ansible/remote/hosts.ansible.yml
+++ b/infra/ansible/remote/hosts.ansible.yml
@@ -5,14 +5,31 @@ nodes:
       ansible_host: #Your host IP
       ansible_user: #Your host User
       ansible_ssh_private_key_file: ~/.ssh/id_rsa
+      ansible_ssh_private_key_password: #Your private key password. Empty in case of a non-password private key
+      
+      #The parameters below it's for NodeCTL installation, if you already have it installed, just put your current information.
+      nodectl_user: nodeadmin #Nodectl user, default nodeadmin. It will create this user if you need to install nodectl
+      nodectl_user_password: #Nodectl user password. It will create the user above with this password
+
     node-2:
       ansible_host: #Your host IP
       ansible_user: #Your host User
       ansible_ssh_private_key_file: ~/.ssh/id_rsa
+      ansible_ssh_private_key_password: #Your private key password. Empty in case of a non-password private key
+
+      #The parameters below it's for NodeCTL installation, if you already have it installed, just put your current information.
+      nodectl_user: nodeadmin #Nodectl user, default nodeadmin. It will create this user if you need to install nodectl
+      nodectl_user_password: #Nodectl user password. It will create the user above with this password
+
     node-3:
       ansible_host: #Your host IP
       ansible_user: #Your host User
       ansible_ssh_private_key_file: ~/.ssh/id_rsa
+      ansible_ssh_private_key_password: #Your private key password. Empty in case of a non-password private key
+
+      #The parameters below it's for NodeCTL installation, if you already have it installed, just put your current information.
+      nodectl_user: nodeadmin #Nodectl user, default nodeadmin. It will create this user if you need to install nodectl
+      nodectl_user_password: #Nodectl user password. It will create the user above with this password
 
   vars:
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
@@ -32,5 +49,6 @@ monitoring:
       ansible_host: #Your host IP
       ansible_user: #Your host User
       ansible_ssh_private_key_file: ~/.ssh/id_rsa
+      ansible_ssh_private_key_password: #Your private key password. Empty in case of a non-password private key
   vars:
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"

--- a/infra/ansible/remote/nodes/playbooks/deploy/deploy.ansible.yml
+++ b/infra/ansible/remote/nodes/playbooks/deploy/deploy.ansible.yml
@@ -5,6 +5,13 @@
   hosts: nodes
   gather_facts: false
   tasks:
+    - name: Create global-l0 directory
+      file:
+        path: /home/{{ ansible_user }}/code/global-l0
+        state: directory
+      async: 300
+      poll: 0
+
     - name: Create metagraph-l0 directory
       file:
         path: /home/{{ ansible_user }}/code/metagraph-l0
@@ -39,6 +46,11 @@
       copy:
         src: "{{ lookup('env', 'INFRA_PATH') }}/docker/shared/jars/cl-wallet.jar"
         dest: /home/{{ ansible_user }}/code
+
+    - name: Copy cl-keytool.jar and cl-wallet.jar files to global-l0
+      shell: |
+        cp /home/{{ ansible_user }}/code/cl-keytool.jar /home/{{ ansible_user }}/code/global-l0
+        cp /home/{{ ansible_user }}/code/cl-wallet.jar /home/{{ ansible_user }}/code/global-l0
 
     - name: Copy cl-keytool.jar and cl-wallet.jar files to metagraph-l0
       shell: |
@@ -127,6 +139,10 @@
         src: "{{ lookup('env', 'SOURCE_PATH') }}/p12-files/{{ all_nodes[0].key_file.name }}"
         dest: /home/{{ ansible_user }}/code
 
+    - name: Copy p12 file to global-l0
+      shell: |
+        cp /home/{{ ansible_user }}/code/{{ all_nodes[0].key_file.name }} /home/{{ ansible_user }}/code/global-l0
+
     - name: Copy p12 file to metagraph-l0
       shell: |
         cp /home/{{ ansible_user }}/code/{{ all_nodes[0].key_file.name }} /home/{{ ansible_user }}/code/metagraph-l0
@@ -153,6 +169,10 @@
       copy:
         src: "{{ lookup('env', 'SOURCE_PATH') }}/p12-files/{{ all_nodes[1].key_file.name }}"
         dest: /home/{{ ansible_user }}/code
+
+    - name: Copy p12 file to global-l0
+      shell: |
+        cp /home/{{ ansible_user }}/code/{{ all_nodes[1].key_file.name }} /home/{{ ansible_user }}/code/global-l0
 
     - name: Copy p12 file to metagraph-l0
       shell: |
@@ -181,6 +201,10 @@
         src: "{{ lookup('env', 'SOURCE_PATH') }}/p12-files/{{ all_nodes[2].key_file.name }}"
         dest: /home/{{ ansible_user }}/code
 
+    - name: Copy p12 file to global-l0
+      shell: |
+        cp /home/{{ ansible_user }}/code/{{ all_nodes[2].key_file.name }} /home/{{ ansible_user }}/code/global-l0
+
     - name: Copy p12 file to metagraph-l0
       shell: |
         cp /home/{{ ansible_user }}/code/{{ all_nodes[2].key_file.name }} /home/{{ ansible_user }}/code/metagraph-l0
@@ -196,3 +220,107 @@
     - name: Cleaning file
       shell: |
         rm -f /home/{{ ansible_user }}/code/{{ all_nodes[0].key_file.name }}
+
+- name: Download nodectl
+  hosts: nodes
+  become: yes
+  gather_facts: false
+  tasks:
+    - name: Check if nodectl_user is not provided
+      fail:
+        msg: "nodectl_user is not defined, please check your hosts file and fill the field"
+      when: not (skip_nodectl | bool) and (nodectl_user is not defined or nodectl_user | default('') | trim == '')
+
+    - name: Check if nodectl_user_password is not provided
+      fail:
+        msg: "nodectl_user_password is not defined, please check your hosts file and fill the field"
+      when: not (skip_nodectl | bool) and (nodectl_user_password is not defined or nodectl_user_password | trim == "")
+
+    - name: Check if nodectl is already installed
+      command: which nodectl
+      register: result
+      ignore_errors: true
+      when: not (skip_nodectl | bool)
+
+    - name: Filling nodectl_already_installed
+      set_fact:
+        nodectl_already_installed: "{{ result.rc == 0 }}"
+      when: not (skip_nodectl | bool)
+        
+    - name: Download nodectl from GitHub
+      get_url:
+        url: https://github.com/stardustcollective/nodectl/releases/download/v2.13.0/nodectl_x86_64
+        dest: /usr/local/bin/nodectl
+        mode: '0755'
+        force: yes
+      when: not (skip_nodectl | bool) and not nodectl_already_installed 
+
+    - name: Check if nodectl is available
+      shell: which nodectl
+      when: not (skip_nodectl | bool) and not nodectl_already_installed
+
+- name: Install nodectl node 1
+  hosts: node-1
+  become: yes
+  gather_facts: false
+  vars:
+    all_nodes: "{{ lookup('env', 'NODES') }}"
+    network_name: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+  tasks:
+    - name: Run quick-install on node-1
+      shell: >
+        sudo nodectl install --quick-install \
+        --user {{ nodectl_user }} \
+        --user-password {{ nodectl_user_password }} \
+        --cluster-config {{ network_name }} \
+        --p12-passphrase {{ all_nodes[0].key_file.password }} \
+        --p12-alias {{ all_nodes[0].key_file.alias }} \
+        --p12-migration-path /home/{{ ansible_user }}/code/global-l0/{{ all_nodes[0].key_file.name }} \
+        --confirm
+      async: 900
+      poll: 30
+      when: not (skip_nodectl | bool) and not nodectl_already_installed
+
+- name: Install nodectl node 2
+  hosts: node-2
+  become: yes
+  gather_facts: false
+  vars:
+    all_nodes: "{{ lookup('env', 'NODES') }}"
+    network_name: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+  tasks:
+    - name: Run quick-install on node-2
+      shell: >
+        sudo nodectl install --quick-install \
+        --user {{ nodectl_user }} \
+        --user-password {{ nodectl_user_password }} \
+        --cluster-config {{ network_name }} \
+        --p12-passphrase {{ all_nodes[1].key_file.password }} \
+        --p12-alias {{ all_nodes[1].key_file.alias }} \
+        --p12-migration-path /home/{{ ansible_user }}/code/global-l0/{{ all_nodes[1].key_file.name }} \
+        --confirm
+      async: 900
+      poll: 30
+      when: not (skip_nodectl | bool) and not nodectl_already_installed
+
+- name: Install nodectl node 3
+  hosts: node-3
+  become: yes
+  gather_facts: false
+  vars:
+    all_nodes: "{{ lookup('env', 'NODES') }}"
+    network_name: "{{ lookup('env', 'DEPLOY_NETWORK_NAME') }}"
+  tasks:
+    - name: Run quick-install on node-3
+      shell: >
+        sudo nodectl install --quick-install \
+        --user {{ nodectl_user }} \
+        --user-password {{ nodectl_user_password }} \
+        --cluster-config {{ network_name }} \
+        --p12-passphrase {{ all_nodes[2].key_file.password }} \
+        --p12-alias {{ all_nodes[2].key_file.alias }} \
+        --p12-migration-path /home/{{ ansible_user }}/code/global-l0/{{ all_nodes[2].key_file.name }} \
+        --confirm
+      async: 900
+      poll: 30
+      when: not (skip_nodectl | bool) and not nodectl_already_installed

--- a/scripts/hydra
+++ b/scripts/hydra
@@ -51,6 +51,7 @@ function load_scripts() {
   source ./utils/echo-colors.sh
   source ./utils/get-information.sh
   source ./utils/validations.sh
+  source ./utils/ssh-key-operations.sh
 
   source ./migrations/migrations.sh
 
@@ -227,6 +228,7 @@ function status() {
 # -> DEFAULT_ANSIBLE_HOSTS_FILE: infra/ansible/remote/hosts.ansible.yml
 # -> DEFAULT_ANSIBLE_NODES_DEPLOY_PLAYBOOK_FILE: infra/ansible/remote/nodes/playbooks/deploy.ansible.yml
 # @flag   --force_genesis                      Force metagraph to deploy as genesis
+# @flag   --skip_nodectl                       Skip nodectl installation
 function remote-deploy() {
   check_if_should_run_update
 
@@ -244,6 +246,7 @@ function remote-deploy() {
 # -> DEFAULT_ANSIBLE_HOSTS_FILE: infra/ansible/remote/hosts.ansible.yml
 # -> DEFAULT_ANSIBLE_START_PLAYBOOK_FILE: infra/ansible/remote/nodes/playbooks/start/start.ansible.yml
 # @flag   --force_genesis                      Force metagraph to run as genesis
+# @flag   --skip_nodectl                       Skip nodectl validation
 function remote-start() {
   check_if_should_run_update
 

--- a/scripts/hydra-operations/remote-deploy-monitoring-service.sh
+++ b/scripts/hydra-operations/remote-deploy-monitoring-service.sh
@@ -72,6 +72,7 @@ function remote_deploy_monitoring_service() {
   echo_title "################################## REMOTE DEPLOY ##################################"
   check_ansible
   check_monitoring_host_file
+  add_ssh_key_to_agent monitoring
 
   check_if_config_json_is_valid
   check_private_key_paths
@@ -82,5 +83,5 @@ function remote_deploy_monitoring_service() {
   export ANSIBLE_DEPRECATION_WARNINGS=False
 
   ansible-playbook -i $ANSIBLE_HOSTS_FILE $ANSIBLE_MONITORING_DEPLOY_PLAYBOOK_FILE
-  
+  remove_ssh_key_from_agent monitoring
 }

--- a/scripts/hydra-operations/remote-deploy.sh
+++ b/scripts/hydra-operations/remote-deploy.sh
@@ -34,4 +34,8 @@ function remote_deploy_metagraph() {
   
   ansible-playbook -e "force_genesis=$force_genesis" -e "skip_nodectl=$skip_nodectl" -e "deploy_cl1=$deploy_cl1" -e "deploy_dl1=$deploy_dl1" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_DEPLOY_PLAYBOOK_FILE
   remove_ssh_key_from_agent nodes
+  echo_title "#####################################################################################"
+  echo_title "NOTE: BE SURE TO HAVE YOUR GLOBAL L0 NODES READY AND HEALTHY BEFORE USING THE remote-start COMMAND, OTHERWISE THE COMMAND WILL FAIL"
+  echo_title "TAKE A LOOK AT YOUR NODES BEFORE STARTING, IF YOU'RE USING NODECTL YOU CAN CHECK THE STATUS BY TYPING: sudo nodectl status"
+  echo_title "#####################################################################################"
 }

--- a/scripts/hydra-operations/remote-deploy.sh
+++ b/scripts/hydra-operations/remote-deploy.sh
@@ -4,6 +4,7 @@ function remote_deploy_metagraph() {
   echo_title "################################## REMOTE DEPLOY ##################################"
   check_ansible
   check_nodes_host_file
+  add_ssh_key_to_agent nodes
 
   echo_yellow "Deploying on remote hosts"
   echo_white ""
@@ -25,6 +26,12 @@ function remote_deploy_metagraph() {
     force_genesis=false
   fi
   
-  ansible-playbook -e "force_genesis=$force_genesis" -e "deploy_cl1=$deploy_cl1" -e "deploy_dl1=$deploy_dl1" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_DEPLOY_PLAYBOOK_FILE
+  if [ ! -z "$argc_skip_nodectl" ]; then
+    skip_nodectl=true
+  else
+    skip_nodectl=false
+  fi
   
+  ansible-playbook -e "force_genesis=$force_genesis" -e "skip_nodectl=$skip_nodectl" -e "deploy_cl1=$deploy_cl1" -e "deploy_dl1=$deploy_dl1" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_DEPLOY_PLAYBOOK_FILE
+  remove_ssh_key_from_agent nodes
 }

--- a/scripts/hydra-operations/remote-start-monitoring-service.sh
+++ b/scripts/hydra-operations/remote-start-monitoring-service.sh
@@ -4,6 +4,7 @@ function remote_start_monitoring_service() {
   echo_title "################################## REMOTE START MONITORING SERVICE ##################################"
   check_ansible
   check_monitoring_host_file
+  add_ssh_key_to_agent monitoring
 
   echo_yellow "Starting monitoring service on remote host..."
   echo_white ""
@@ -17,5 +18,5 @@ function remote_start_monitoring_service() {
   export ANSIBLE_DEPRECATION_WARNINGS=False
 
   ansible-playbook -e "force_restart=$force_restart" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_MONITORING_START_PLAYBOOK_FILE
-  
+  remove_ssh_key_from_agent monitoring
 }

--- a/scripts/hydra-operations/remote-start.sh
+++ b/scripts/hydra-operations/remote-start.sh
@@ -1,7 +1,76 @@
 #!/usr/bin/env bash
 
+function check_if_global_node_are_healthy() {
+  echo
+  echo_title "CHECKING IF YOUR PROVIDED GLOBAL L0 NODE IS HEALTHY"
+
+  user_node_info_request=$(curl -s http://$DEPLOY_NETWORK_HOST_IP:$DEPLOY_NETWORK_HOST_PUBLIC_PORT/node/info)
+  USER_NODE_STATE=$(echo $user_node_info_request | jq -r '.state')
+  USER_TESSELLATION_VERSION=$(echo $user_node_info_request | jq -r '.version')
+
+  load_balancer_node_info_request=$(curl -s https://l0-lb-$DEPLOY_NETWORK_NAME.constellationnetwork.io/node/info)
+  LOAD_BALANCER_TESSELLATION_VERSION=$(echo $load_balancer_node_info_request | jq -r '.version')
+
+  echo
+  echo_title "Your node information"
+  echo_url "ID:" $DEPLOY_NETWORK_HOST_ID
+  echo_url "IP:" $DEPLOY_NETWORK_HOST_IP
+  echo_url "PUBLIC PORT:" $DEPLOY_NETWORK_HOST_PUBLIC_PORT
+  echo_url "NODE STATE:" $USER_NODE_STATE
+  echo_url "TESSELLATION VERSION:" $USER_TESSELLATION_VERSION
+  echo
+
+  echo_title "Network information"
+  echo_url "TESSELLATION VERSION:" $LOAD_BALANCER_TESSELLATION_VERSION
+
+  echo
+  echo
+
+  if [ "$USER_TESSELLATION_VERSION" != "$LOAD_BALANCER_TESSELLATION_VERSION" ]; then
+    echo_red "Your node has a different Tessellation version than the network, please check your node before continuing"
+    echo_red "Node: $USER_TESSELLATION_VERSION"
+    echo_red "Network: $LOAD_BALANCER_TESSELLATION_VERSION"
+    exit 1
+  fi
+
+  if [ "$USER_NODE_STATE" != "Ready" ]; then
+    echo_red "Your node should be on Ready state, please check your node before continuing"
+    exit 1
+  fi
+
+  user_global_snapshots_request=$(curl -s -H "Accept: application/json" http://$DEPLOY_NETWORK_HOST_IP:$DEPLOY_NETWORK_HOST_PUBLIC_PORT/global-snapshots/latest)
+  USER_LAST_SNAPSHOT_HASH=$(echo $user_global_snapshots_request | jq -r '.value.lastSnapshotHash')
+  USER_ORDINAL=$(echo $user_global_snapshots_request | jq -r '.value.ordinal')
+
+  load_balancer_global_snapshots_request=$(curl -s -H "Accept: application/json" https://l0-lb-$DEPLOY_NETWORK_NAME.constellationnetwork.io/global-snapshots/$USER_ORDINAL)
+  LOAD_BALANCER_LAST_SNAPSHOT_HASH=$(echo $load_balancer_global_snapshots_request | jq -r '.value.lastSnapshotHash')
+  LOAD_BALANCER_ORDINAL=$(echo $load_balancer_global_snapshots_request | jq -r '.value.ordinal')
+
+  echo_title "Your node snapshot information"
+  echo_url "ORDINAL" $USER_ORDINAL
+  echo_url "LAST SNAPSHOT HASH:" $USER_LAST_SNAPSHOT_HASH
+  echo
+
+  echo_title "Network snapshot information"
+  echo_url "ORDINAL" $LOAD_BALANCER_ORDINAL
+  echo_url "LAST SNAPSHOT HASH:" $LOAD_BALANCER_LAST_SNAPSHOT_HASH
+  echo
+  echo
+  
+  if [ "$USER_LAST_SNAPSHOT_HASH" != "$LOAD_BALANCER_LAST_SNAPSHOT_HASH" ]; then
+    echo_red "Your node has a different snapshot hash than the network, probably your node has forked. Please restart your node before continuing"
+    echo_red "Node: $USER_LAST_SNAPSHOT_HASH"
+    echo_red "Network: $LOAD_BALANCER_LAST_SNAPSHOT_HASH"
+    exit 1
+  fi
+
+  echo_green "YOUR NODE IS HEALTHY"
+  echo_white
+}
+
 function remote_start_metagraph() {
   echo_title "################################## REMOTE START ##################################"
+  check_if_global_node_are_healthy
   check_ansible
   check_nodes_host_file
   add_ssh_key_to_agent nodes
@@ -15,8 +84,8 @@ function remote_start_metagraph() {
   else
     force_genesis=false
   fi
-
+exit 0
   ansible-playbook -e "force_genesis=$force_genesis" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_START_PLAYBOOK_FILE
   remove_ssh_key_from_agent nodes
-  
+
 }

--- a/scripts/hydra-operations/remote-start.sh
+++ b/scripts/hydra-operations/remote-start.sh
@@ -84,7 +84,7 @@ function remote_start_metagraph() {
   else
     force_genesis=false
   fi
-exit 0
+
   ansible-playbook -e "force_genesis=$force_genesis" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_START_PLAYBOOK_FILE
   remove_ssh_key_from_agent nodes
 

--- a/scripts/hydra-operations/remote-start.sh
+++ b/scripts/hydra-operations/remote-start.sh
@@ -4,6 +4,7 @@ function remote_start_metagraph() {
   echo_title "################################## REMOTE START ##################################"
   check_ansible
   check_nodes_host_file
+  add_ssh_key_to_agent nodes
 
   check_network $DEPLOY_NETWORK_NAME
 
@@ -16,5 +17,6 @@ function remote_start_metagraph() {
   fi
 
   ansible-playbook -e "force_genesis=$force_genesis" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_START_PLAYBOOK_FILE
+  remove_ssh_key_from_agent nodes
   
 }

--- a/scripts/hydra-operations/remote-status.sh
+++ b/scripts/hydra-operations/remote-status.sh
@@ -22,6 +22,8 @@ function fetch_node_info() {
 function remote_status() {
   echo_title "################################## REMOTE STATUS ##################################"
   check_nodes_host_file
+  add_ssh_key_to_agent nodes
+
   metagraph_l0_port=$(yq eval '.nodes.vars.base_metagraph_l0_public_port' $ANSIBLE_HOSTS_FILE)
   currency_l1_port=$(yq eval '.nodes.vars.base_currency_l1_public_port' $ANSIBLE_HOSTS_FILE)
   data_l1_port=$(yq eval '.nodes.vars.base_data_l1_public_port' $ANSIBLE_HOSTS_FILE)
@@ -52,6 +54,6 @@ function remote_status() {
     ((index++))
     echo
   done < <(yq eval -o=j $ANSIBLE_HOSTS_FILE | jq -cr '.nodes.hosts[]')
-
+  remove_ssh_key_from_agent nodes
   
 }

--- a/scripts/utils/ssh-key-operations.sh
+++ b/scripts/utils/ssh-key-operations.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+function add_ssh_key_to_agent() {
+  echo_white "Adding ssh keys to ssh-agent..."
+  eval $(ssh-agent -s)
+  while IFS= read -r node; do
+    ssh_private_key_file=$(jq -r '.ansible_ssh_private_key_file' <<<"$node")
+    ssh_private_key_password=$(jq -r '.ansible_ssh_private_key_password' <<<"$node")
+
+    decrypted_ssh_private_key_file="${ssh_private_key_file%.pem}.decrypt.pem"
+    openssl rsa -in $ssh_private_key_file -out $decrypted_ssh_private_key_file -passin pass:$ssh_private_key_password &>/dev/null
+
+    ssh-add $decrypted_ssh_private_key_file &>/dev/null
+  done < <(yq eval -o=j $ANSIBLE_HOSTS_FILE | jq -cr ".$1.hosts[]")
+  echo_green "ssh keys added to ssh-agent"
+}
+
+function remove_ssh_key_from_agent() {
+  echo_white "Removing ssh keys from ssh-agent..."
+  while IFS= read -r node; do
+    ssh_private_key_file=$(jq -r '.ansible_ssh_private_key_file' <<<"$node")
+    ssh_private_key_password=$(jq -r '.ansible_ssh_private_key_password' <<<"$node")
+
+    decrypted_ssh_private_key_file="${ssh_private_key_file%.pem}.decrypt.pem"
+    rm -rf $decrypted_ssh_private_key_file &>/dev/null
+    ssh-add -D &>/dev/null
+  done < <(yq eval -o=j $ANSIBLE_HOSTS_FILE | jq -cr ".$1.hosts[]")
+  echo_green "ssh keys removed from ssh-agent"
+}


### PR DESCRIPTION
## Changes
+ Added new integration for nodectl when using `remote-deploy`.
+ This integration checks if nodectl is already installed on the remote instance. If not, it will download nodectl unless the  `--skip_nodectl` flag is used.
+ Implemented a new health check in `remote-start` to verify the global node specified in euclid.json.
+ Fixed a bug with `ssh-agent` add that prevented it from working with encrypted files.
+ Keys are now automatically added to `ssh-agent`.
+ Updated `hosts.ansible.yml` with new parameters related to nodectl and ssh-key-password.