### PR TITLE
Adding fees messages in euclid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ source/project/*
 source/metagraph-l0/genesis/genesis.address
 source/metagraph-l0/genesis/genesis.snapshot
 source/*-monitoring-service
+source/p12-files/*
+infra/docker/shared/genesis/*
+
+!source/p12-files/token-key-1.p12
+!source/p12-files/token-key-2.p12
+!source/p12-files/token-key-3.p12

--- a/README.md
+++ b/README.md
@@ -320,10 +320,6 @@ OPTIONS:
   -h, --help   
 ```
 * --force_genesis: Use this flag when you want your metagraph to start from genesis. If you have already started a metagraph and need to execute from genesis again, use this command.
-
-* --owner_p12_file_name: This parameter specifies the wallet to charge fees on snapshots. Ensure this file is in the `p12-files` directory. We will validate if the file exists in the directory and, if so, send it to the remote `metagraph-l0` directory.
-
-* --staking_p12_file_name: This parameter specifies the wallet to check the balance to reduce fees according to the amount of DAG in the balance. Ensure this file is in the `p12-files` directory. We will validate if the file exists in the directory and, if so, send it to the remote `metagraph-l0` directory.
  
 ### `hydra remote-start`
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ OPTIONS:
 ```
 * --force_genesis: Use this flag when you want your metagraph to start from genesis. If you have already started a metagraph and need to execute from genesis again, use this command.
  
+**NOTE: You'll be prompted to proceed with force_genesis since it will delete all the previous data**
 ### `hydra remote-start`
 
 This method initiates the remote startup of your metagraph in one of the available networks: integrationnet or mainnet. The network should be set in `euclid.json` under `deploy` -> `network`
@@ -373,7 +374,7 @@ OPTIONS:
 * --force_owner_message: Use this flag when you want your metagraph to force sending the owner message. For example, if you want to change the owner address, provide this flag.
 * --force_staking_message: Use this flag when you want your metagraph to force sending the staking message. For example, if you want to change the staking address, provide this flag.
 
-**NOTE:** When you provide any of the owner or staking parameters, you must provide all the parameters, otherwise, it will fail.
+**NOTE: You'll be prompted to proceed with force_genesis since it will delete all the previous data**
 
 ### `hydra remote-status`
 This method will return the status of your remote hosts. You should see the following:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ COMMANDS:
   remote-deploy                     Remotely deploy to cloud instances using Ansible [aliases: remote_deploy]
   remote-start                      Remotely start the metagraph on cloud instances using Ansible [aliases: remote_start]
   remote-status                     Check the status of the remote nodes
+  remote-logs                       Get the logs from the remote hosts
+  remote-snapshot-fee-config        Get the remote snapshot fee config
   update                            Update Euclid
   logs                              Get the logs from containers
   install-monitoring-service        Download the metagraph-monitoring-service (https://github.com/Constellation-Labs/metagraph-monitoring-service) [aliases: install_monitoring_service]
@@ -305,7 +307,24 @@ Each directory will be created with `cl-keytool.jar`, `cl-wallet.jar`, and a P12
 **In `code/data-l1`:**
 -   data-l1.jar     // The executable for the dL1 layer
 
+#### Parameters
+If you run the command `./hydra remote-deploy -h` you should see something like
 
+```
+Remotely deploy to cloud instances using Ansible
+
+USAGE: hydra remote-deploy [OPTIONS]
+
+OPTIONS:
+      --force_genesis                                  Force metagraph to deploy as genesis
+  -h, --help   
+```
+* --force_genesis: Use this flag when you want your metagraph to start from genesis. If you have already started a metagraph and need to execute from genesis again, use this command.
+
+* --owner_p12_file_name: This parameter specifies the wallet to charge fees on snapshots. Ensure this file is in the `p12-files` directory. We will validate if the file exists in the directory and, if so, send it to the remote `metagraph-l0` directory.
+
+* --staking_p12_file_name: This parameter specifies the wallet to check the balance to reduce fees according to the amount of DAG in the balance. Ensure this file is in the `p12-files` directory. We will validate if the file exists in the directory and, if so, send it to the remote `metagraph-l0` directory.
+ 
 ### `hydra remote-start`
 
 This method initiates the remote startup of your metagraph in one of the available networks: integrationnet or mainnet. The network should be set in `euclid.json` under `deploy` -> `network`
@@ -339,6 +358,26 @@ Each layer directory on every node contains a folder named `logs`. You can monit
 `tail -f logs/app.log`
 
 **NOTE:** Don't forget to add your hosts' information, such as host, user, and SSH key file, to your `infra/ansible/remote/hosts.ansible.yml` file.
+
+#### Parameters
+If you run the command `./hydra remote-start -h` you should see something like
+
+```
+Remotely start the metagraph on cloud instances using Ansible
+
+USAGE: hydra remote-start [OPTIONS]
+
+OPTIONS:
+      --force_genesis                                    Force metagraph to run as genesis
+      --force_owner_message                              Force to send owner message
+      --force_staking_message                            Force to send staking message
+  -h, --help    
+```
+* --force_genesis: Use this flag when you want your metagraph to start from genesis. If you have already started a metagraph and need to execute from genesis again, use this command.
+* --force_owner_message: Use this flag when you want your metagraph to force sending the owner message. For example, if you want to change the owner address, provide this flag.
+* --force_staking_message: Use this flag when you want your metagraph to force sending the staking message. For example, if you want to change the staking address, provide this flag.
+
+**NOTE:** When you provide any of the owner or staking parameters, you must provide all the parameters, otherwise, it will fail.
 
 ### `hydra remote-status`
 This method will return the status of your remote hosts. You should see the following:

--- a/euclid.json
+++ b/euclid.json
@@ -1,6 +1,6 @@
 {
   "github_token": "",
-  "version": "0.11.0-SNAPSHOT",
+  "version": "0.11.0",
   "tessellation_version": "2.3.3",
   "project_name": "custom-project",
   "framework": {
@@ -45,6 +45,22 @@
   ],
   "docker": {
     "start_grafana_container": false
+  },
+  "snapshot_fees": {
+    "owner": {
+      "key_file": {
+        "name": "token-key.p12",
+        "alias": "token-key",
+        "password": "password"
+      }
+    },
+    "staking": {
+      "key_file": {
+        "name": "token-key-1.p12",
+        "alias": "token-key-1",
+        "password": "password"
+      }
+    }
   },
   "deploy": {
     "network": {

--- a/infra/ansible/remote/nodes/playbooks/deploy/deploy.ansible.yml
+++ b/infra/ansible/remote/nodes/playbooks/deploy/deploy.ansible.yml
@@ -196,3 +196,36 @@
     - name: Cleaning file
       shell: |
         rm -f /home/{{ ansible_user }}/code/{{ all_nodes[0].key_file.name }}
+
+- name: Send fees p12 files to nodes
+  hosts: nodes
+  gather_facts: false
+  vars:
+     owner_p12_file_name: "{{ owner_p12_file_name }}"
+     staking_p12_file_name: "{{ staking_p12_file_name }}"
+  tasks:
+    - name: Check if owner file exists
+      stat:
+        path: "{{ lookup('env', 'SOURCE_PATH') }}/p12-files/{{ owner_p12_file_name }}"
+      register: owner_p12_file
+      delegate_to: localhost
+      when: not (owner_p12_file_name is undefined or owner_p12_file_name == "")
+
+    - name: Copy owner file to remote node
+      copy:
+        src: "{{ lookup('env', 'SOURCE_PATH') }}/p12-files/{{ owner_p12_file_name }}"
+        dest: "/home/{{ ansible_user }}/code/metagraph-l0/{{ owner_p12_file_name }}"
+      when: not (owner_p12_file_name is undefined or owner_p12_file_name == "") and owner_p12_file.stat.exists
+
+    - name: Check if staking file exists
+      stat:
+        path: "{{ lookup('env', 'SOURCE_PATH') }}/p12-files/{{ staking_p12_file_name }}"
+      register: staking_p12_file
+      when: not (staking_p12_file_name is undefined or staking_p12_file_name == "")
+      delegate_to: localhost
+
+    - name: Copy staking file to remote node if it exists
+      copy:
+        src: "{{ lookup('env', 'SOURCE_PATH') }}/p12-files/{{ staking_p12_file_name }}"
+        dest: "/home/{{ ansible_user }}/code/metagraph-l0/{{ staking_p12_file_name }}"
+      when: not (staking_p12_file_name is undefined or staking_p12_file_name == "") and staking_p12_file.stat.exists

--- a/infra/ansible/remote/nodes/playbooks/start/metagraph-l0/genesis.ansible.yml
+++ b/infra/ansible/remote/nodes/playbooks/start/metagraph-l0/genesis.ansible.yml
@@ -228,6 +228,14 @@
     retries: 0
   when: should_run_genesis
 
+- name: Wait 2 minutes before stopping current execution
+  pause:
+    minutes: 2
+  when: >
+      owner_p12_file_name is defined and 
+      owner_p12_file_name != "" and 
+      should_run_genesis or force_owner_message_bool
+
 - name: Find metagraph-l0 process ID by port
   shell: "lsof -t -i:{{ base_metagraph_l0_public_port }}"
   register: l0_process_id

--- a/infra/ansible/remote/nodes/playbooks/start/metagraph-l0/genesis.ansible.yml
+++ b/infra/ansible/remote/nodes/playbooks/start/metagraph-l0/genesis.ansible.yml
@@ -80,7 +80,7 @@
     msg: "File /home/{{ ansible_user }}/code/metagraph-l0/{{ staking_p12_file_name }} does not exist"
   when: not (staking_p12_file_name is undefined or staking_p12_file_name == "") and not staking_file.stat.exists
 
-- name: Fetch the latest combined snapshot
+- name: Fetch the latest combined snapshot from global network
   uri:
     url: "http://{{ gl0_ip }}:{{ gl0_port }}/global-snapshots/latest/combined"
     method: GET
@@ -90,17 +90,17 @@
   register: latest_combined_snapshot_response
   when: should_run_genesis or force_owner_message_bool or force_staking_message_bool
 
-- name: Check if the fetch was successful
+- name: Check if the snapshot fetch was successful
   fail:
     msg: "Error fetching the latest combined snapshot."
   when: (should_run_genesis or force_owner_message_bool or force_staking_message_bool) and latest_combined_snapshot_response.status != 200
 
-- name: Convert JSON response content to a fact
+- name: Convert response to JSON
   set_fact:
     json_response: "{{ latest_combined_snapshot_response.content | from_json }}"
   when: should_run_genesis or force_owner_message_bool or force_staking_message_bool
 
-- name: Parse the response to extract the last messages
+- name: Parse the response to extract the metagraph last messages
   set_fact:
     snapshot_fees_messages: "{{ json_response | json_query('[1].lastCurrencySnapshots.' ~ metagraph_id ~ '.Right[1].lastMessages') }}"
   when: should_run_genesis or force_owner_message_bool or force_staking_message_bool

--- a/infra/ansible/remote/nodes/playbooks/start/metagraph-l0/genesis.ansible.yml
+++ b/infra/ansible/remote/nodes/playbooks/start/metagraph-l0/genesis.ansible.yml
@@ -1,25 +1,42 @@
 ---
-- name: Check execution type
+- name: Check if we already have incremental snapshots
+  stat:
+    path: "/home/{{ ansible_user }}/code/metagraph-l0/data/incremental_snapshot"
+  register: folder_exists
+
+- name: Set default values for variables if not defined
   set_fact:
-    force_genesis_bool: "{{ force_genesis | default(true) | bool }}"
+    force_genesis: "{{ force_genesis | default(false) }}"
+    force_owner_message: "{{ force_owner_message | default(false) }}"
+    force_staking_message: "{{ force_staking_message | default(false) }}"
+
+- name: Convert execution type variables to boolean
+  set_fact:
+    force_genesis_bool: "{{ force_genesis | bool }}"
+    force_owner_message_bool: "{{ force_owner_message | bool }}"
+    force_staking_message_bool: "{{ force_staking_message | bool }}"
+
+- name: Determine if should run genesis
+  set_fact:
+    should_run_genesis: "{{ not folder_exists.stat.exists or force_genesis_bool }}"
 
 - name: Get current timestamp
   set_fact:
     current_time: "{{ lookup('pipe', 'date +%Y-%m-%dT%H:%M:%S%z') }}"
-  when: force_genesis_bool
+  when: should_run_genesis
 
 - name: Ensure archived-data directory exists
   ansible.builtin.file:
     path: /home/{{ ansible_user }}/code/metagraph-l0/archived-data
     state: directory
-  when: force_genesis_bool
+  when: should_run_genesis
 
 - name: Save previous data directory
   shell: |
     cd "/home/{{ ansible_user }}/code/metagraph-l0"
     mv data archived-data/data_{{ current_time }}
   ignore_errors: true
-  when: force_genesis_bool
+  when: should_run_genesis
 
 - name: Check if metagraph-l0.jar exists
   stat:
@@ -41,10 +58,194 @@
     msg: "File /home/{{ ansible_user }}/code/metagraph-l0/{{ cl_keystore }} does not exist"
   when: not token_file.stat.exists
 
-- name: Check if we already have incremental snapshots
+- name: Check if owner file exists
   stat:
-    path: "/home/{{ ansible_user }}/code/metagraph-l0/data/incremental_snapshot"
-  register: folder_exists
+    path: "/home/{{ ansible_user }}/code/metagraph-l0/{{ owner_p12_file_name }}"
+  register: owner_file
+  when: not (owner_p12_file_name is undefined or owner_p12_file_name == "") 
+
+- name: Throw an error if the owner file doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/metagraph-l0/{{ owner_p12_file_name }} does not exist"
+  when: not (owner_p12_file_name is undefined or owner_p12_file_name == "")  and not owner_file.stat.exists
+
+- name: Check if staking file exists
+  stat:
+    path: "/home/{{ ansible_user }}/code/metagraph-l0/{{ staking_p12_file_name }}"
+  register: staking_file
+  when: not (staking_p12_file_name is undefined or staking_p12_file_name == "")
+
+- name: Throw an error if the staking file doesn't exist
+  fail:
+    msg: "File /home/{{ ansible_user }}/code/metagraph-l0/{{ staking_p12_file_name }} does not exist"
+  when: not (staking_p12_file_name is undefined or staking_p12_file_name == "") and not staking_file.stat.exists
+
+- name: Fetch the latest combined snapshot
+  uri:
+    url: "http://{{ gl0_ip }}:{{ gl0_port }}/global-snapshots/latest/combined"
+    method: GET
+    return_content: yes
+    headers:
+      Accept: "application/json"
+  register: latest_combined_snapshot_response
+  when: should_run_genesis or force_owner_message_bool or force_staking_message_bool
+
+- name: Check if the fetch was successful
+  fail:
+    msg: "Error fetching the latest combined snapshot."
+  when: (should_run_genesis or force_owner_message_bool or force_staking_message_bool) and latest_combined_snapshot_response.status != 200
+
+- name: Convert JSON response content to a fact
+  set_fact:
+    json_response: "{{ latest_combined_snapshot_response.content | from_json }}"
+  when: should_run_genesis or force_owner_message_bool or force_staking_message_bool
+
+- name: Parse the response to extract the last messages
+  set_fact:
+    snapshot_fees_messages: "{{ json_response | json_query('[1].lastCurrencySnapshots.' ~ metagraph_id ~ '.Right[1].lastMessages') }}"
+  when: should_run_genesis or force_owner_message_bool or force_staking_message_bool
+    
+- name: Ensure snapshot_fees_messages is defined
+  set_fact:
+    snapshot_fees_messages: {}
+  when: snapshot_fees_messages is not defined or snapshot_fees_messages is none
+
+- name: Extract Owner parentOrdinal or default to none
+  set_fact:
+    owner_parent_ordinal_raw: "{{ snapshot_fees_messages['Owner']['value']['parentOrdinal'] | default(None) }}"
+  when: (should_run_genesis or force_owner_message_bool) and not (owner_p12_file_name is undefined or owner_p12_file_name == "")
+
+- name: Extract Staking parentOrdinal or default to none
+  set_fact:
+    staking_parent_ordinal_raw: "{{ snapshot_fees_messages['Staking']['value']['parentOrdinal'] | default(None) }}"
+  when: (should_run_genesis or force_staking_message_bool) and not (staking_p12_file_name is undefined or staking_p12_file_name == "")
+
+- name: Calculate owner_parent_ordinal
+  set_fact:
+    owner_parent_ordinal: >-
+      {% if owner_parent_ordinal_raw is not none and owner_parent_ordinal_raw != "" %}
+        {{ (owner_parent_ordinal_raw | int) + 1 }}
+      {% else %}
+        0
+      {% endif %}
+  when: (should_run_genesis or force_owner_message_bool) and not (owner_p12_file_name is undefined or owner_p12_file_name == "")
+
+- name: Calculate staking_parent_ordinal
+  set_fact:
+    staking_parent_ordinal: >-
+      {% if staking_parent_ordinal_raw is not none and staking_parent_ordinal_raw != "" %}
+        {{ (staking_parent_ordinal_raw | int) + 1 }}
+      {% else %}
+        0
+      {% endif %}
+  when: (should_run_genesis or force_staking_message_bool) and not (staking_p12_file_name is undefined or staking_p12_file_name == "")
+
+- name: Trim owner_parent_ordinal
+  set_fact:
+    owner_parent_ordinal: "{{ owner_parent_ordinal | trim }}"
+  when: (should_run_genesis or force_owner_message_bool) and not (owner_p12_file_name is undefined or owner_p12_file_name == "")
+
+- name: Trim staking_parent_ordinal
+  set_fact:
+    staking_parent_ordinal: "{{ staking_parent_ordinal | trim }}"
+  when: (should_run_genesis or force_staking_message_bool) and not (staking_p12_file_name is undefined or staking_p12_file_name == "")
+
+- name: Get owner address
+  environment:
+    CL_KEYSTORE: "{{ owner_p12_file_name }}"
+    CL_KEYALIAS: "{{ owner_p12_alias }}"
+    CL_PASSWORD: "{{ owner_p12_password }}"
+  shell: |
+    cd "/home/{{ ansible_user }}/code/metagraph-l0"
+    java -jar cl-wallet.jar show-address
+  register: owner_address_output 
+  when: not (owner_p12_file_name is undefined or owner_p12_file_name == "") 
+
+- name: Get owner message
+  environment:
+    CL_KEYSTORE: "{{ owner_p12_file_name }}"
+    CL_KEYALIAS: "{{ owner_p12_alias }}"
+    CL_PASSWORD: "{{ owner_p12_password }}"
+  shell: |
+    cd "/home/{{ ansible_user }}/code/metagraph-l0"
+    java -jar cl-wallet.jar create-owner-signing-message --address {{ owner_address_output.stdout }} --parentOrdinal {{ owner_parent_ordinal }} --metagraphId {{ metagraph_id }}
+  register: owner_message_output 
+  when: not (owner_p12_file_name is undefined or owner_p12_file_name == "") 
+
+- name: Get staking address
+  environment:
+    CL_KEYSTORE: "{{ staking_p12_file_name }}"
+    CL_KEYALIAS: "{{ staking_p12_alias }}"
+    CL_PASSWORD: "{{ staking_p12_password }}"
+  shell: |
+    cd "/home/{{ ansible_user }}/code/metagraph-l0"
+    java -jar cl-wallet.jar show-address
+  register: staking_address_output 
+  when: not (staking_p12_file_name is undefined or staking_p12_file_name == "")
+
+- name: Get staking message
+  environment:
+    CL_KEYSTORE: "{{ staking_p12_file_name }}"
+    CL_KEYALIAS: "{{ staking_p12_alias }}"
+    CL_PASSWORD: "{{ staking_p12_password }}"
+  shell: |
+    cd "/home/{{ ansible_user }}/code/metagraph-l0"
+    java -jar cl-wallet.jar create-staking-signing-message --address {{ staking_address_output.stdout }} --parentOrdinal {{ staking_parent_ordinal }}  --metagraphId {{ metagraph_id }}
+  register: staking_message_output
+  when: not (staking_p12_file_name is undefined or staking_p12_file_name == "")
+
+- name: Start as genesis
+  environment:
+    CL_PUBLIC_HTTP_PORT: "{{ base_metagraph_l0_public_port }}"
+    CL_P2P_HTTP_PORT: "{{ base_metagraph_l0_p2p_port }}"
+    CL_CLI_HTTP_PORT: "{{ base_metagraph_l0_cli_port }}"
+
+    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ gl0_ip }}"
+    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ gl0_port }}"
+    CL_GLOBAL_L0_PEER_ID: "{{ gl0_id }}"
+
+    CL_KEYSTORE: "{{ cl_keystore }}"
+    CL_KEYALIAS: "{{ cl_keyalias }}"
+    CL_PASSWORD: "{{ cl_password }}"
+    
+    CL_APP_ENV: "{{ network }}"
+    CL_COLLATERAL: 0
+  shell: |
+    cd /home/{{ ansible_user }}/code/metagraph-l0
+    nohup java -jar metagraph-l0.jar run-genesis genesis.snapshot --ip {{ ansible_host }} > metagraph-l0.log 2>&1 &
+  when: should_run_genesis
+
+- name: Check if node is Ready
+  uri:
+    url: "http://localhost:{{ base_metagraph_l0_public_port }}/node/info"
+    method: GET
+    return_content: yes
+  register: response
+  until: response.status == 200 and ("Ready" in response.content | string or retries >= 100)
+  retries: 120
+  delay: 1
+  vars:
+    retries: 0
+  when: should_run_genesis
+
+- name: Find metagraph-l0 process ID by port
+  shell: "lsof -t -i:{{ base_metagraph_l0_public_port }}"
+  register: l0_process_id
+  ignore_errors: true
+  when: should_run_genesis
+
+- name: Kill metagraph-l0 process
+  shell: "sudo kill -9 {{ l0_process_id.stdout }}"
+  ignore_errors: true
+  when: should_run_genesis
+
+- name: Wait 2 minutes before starting the metagraph
+  pause:
+    minutes: 2
+  when: >
+      owner_p12_file_name is defined and 
+      owner_p12_file_name != "" and 
+      should_run_genesis or force_owner_message_bool
 
 - name: Start as rollback
   environment:
@@ -66,29 +267,42 @@
   shell: |
     cd "/home/{{ ansible_user }}/code/metagraph-l0"
     nohup java -jar metagraph-l0.jar run-rollback --ip {{ ansible_host }} > metagraph-l0.log 2>&1 &
-  when: folder_exists.stat.exists and not force_genesis_bool
 
-- name: Start as genesis
-  environment:
-    CL_PUBLIC_HTTP_PORT: "{{ base_metagraph_l0_public_port }}"
-    CL_P2P_HTTP_PORT: "{{ base_metagraph_l0_p2p_port }}"
-    CL_CLI_HTTP_PORT: "{{ base_metagraph_l0_cli_port }}"
+- name: Check if node is online
+  uri:
+    url: "http://localhost:{{ base_metagraph_l0_public_port }}/node/info"
+    method: GET
+    return_content: yes
+  register: response
+  until: response.status == 200
+  retries: 120
+  delay: 1
+  vars:
+    retries: 0
 
-    CL_GLOBAL_L0_PEER_HTTP_HOST: "{{ gl0_ip }}"
-    CL_GLOBAL_L0_PEER_HTTP_PORT: "{{ gl0_port }}"
-    CL_GLOBAL_L0_PEER_ID: "{{ gl0_id }}"
+- name: Send owner message
+  uri:
+    url: "http://localhost:{{ base_metagraph_l0_public_port }}/currency/message"
+    method: POST
+    body: "{{ owner_message_output.stdout }}"
+    body_format: json
+    status_code: 204, 200
+  register: owner_response
+  when: >
+    owner_p12_file_name is defined and 
+    owner_p12_file_name != "" and 
+    should_run_genesis or force_owner_message_bool
 
-    CL_KEYSTORE: "{{ cl_keystore }}"
-    CL_KEYALIAS: "{{ cl_keyalias }}"
-    CL_PASSWORD: "{{ cl_password }}"
-    
-    CL_APP_ENV: "{{ network }}"
-    CL_COLLATERAL: 0
-  shell: |
-    cd /home/{{ ansible_user }}/code/metagraph-l0
-    nohup java -jar metagraph-l0.jar run-genesis genesis.snapshot --ip {{ ansible_host }} > metagraph-l0.log 2>&1 &
-  when: not folder_exists.stat.exists or force_genesis_bool
-
+- name: Send staking message
+  uri:
+    url: "http://localhost:{{ base_metagraph_l0_public_port }}/currency/message"
+    method: POST
+    body: "{{ staking_message_output.stdout }}"
+    body_format: json
+    status_code: 204, 200
+  register: staking_response
+  when: not (staking_p12_file_name is undefined or staking_p12_file_name == "") or force_staking_message_bool
+  
 - name: Check if node is Ready
   uri:
     url: "http://localhost:{{ base_metagraph_l0_public_port }}/node/info"

--- a/scripts/hydra
+++ b/scripts/hydra
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-function ensure_permissions_on_files_and_directories(){
+function ensure_permissions_on_files_and_directories() {
   chmod -R a+rwx $INFRA_PATH 2>/dev/null
   chmod -R a+rwx $SCRIPTS_PATH 2>/dev/null
   chmod -R a+rwx $SOURCE_PATH 2>/dev/null
@@ -13,7 +13,7 @@ function build_paths() {
     [[ $SCRIPT_PATH != /* ]] && SCRIPT_PATH="$DIR/$SCRIPT_PATH"
   done
   SCRIPT_PATH="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
-  
+
   cd "$SCRIPT_PATH"
   cd ..
   export ROOT_PATH=$(pwd)
@@ -46,6 +46,7 @@ function load_scripts() {
   source ./hydra-operations/install-monitoring-service.sh
   source ./hydra-operations/remote-deploy-monitoring-service.sh
   source ./hydra-operations/remote-start-monitoring-service.sh
+  source ./hydra-operations/remote-snapshot-fee-config.sh
 
   source ./template/custom-template.sh
 
@@ -227,13 +228,19 @@ function status() {
 # @alias remote_deploy
 # -> DEFAULT_ANSIBLE_HOSTS_FILE: infra/ansible/remote/hosts.ansible.yml
 # -> DEFAULT_ANSIBLE_NODES_DEPLOY_PLAYBOOK_FILE: infra/ansible/remote/nodes/playbooks/deploy.ansible.yml
-# @flag   --force_genesis                      Force metagraph to deploy as genesis
+# @flag   --force_genesis                Force metagraph to deploy as genesis
 function remote-deploy() {
   build_paths
   check_if_should_run_update
 
   ensure_permissions_on_files_and_directories
   load_scripts
+
+  check_if_owner_and_staking_address_are_equal
+  confirm_force_genesis
+
+  check_metagraph_owner_fees_file_exists $SNAPSHOT_FEES_OWNER_FILE_NAME
+  check_metagraph_staking_fees_file_exists $SNAPSHOT_FEES_STAKING_FILE_NAME
 
   remote_deploy_metagraph
 
@@ -244,13 +251,21 @@ function remote-deploy() {
 # @alias remote_start
 # -> DEFAULT_ANSIBLE_HOSTS_FILE: infra/ansible/remote/hosts.ansible.yml
 # -> DEFAULT_ANSIBLE_START_PLAYBOOK_FILE: infra/ansible/remote/nodes/playbooks/start/start.ansible.yml
-# @flag   --force_genesis                      Force metagraph to run as genesis
+# @flag   --force_genesis                Force metagraph to run as genesis
+# @flag   --force_owner_message          Force to send owner message
+# @flag   --force_staking_message        Force to send owner message
 function remote-start() {
   build_paths
   check_if_should_run_update
 
   ensure_permissions_on_files_and_directories
   load_scripts
+  
+  check_if_owner_and_staking_address_are_equal
+  confirm_force_genesis
+
+  check_metagraph_owner_fees_information $SNAPSHOT_FEES_OWNER_FILE_NAME $SNAPSHOT_FEES_OWNER_ALIAS $SNAPSHOT_FEES_OWNER_PASSWORD
+  check_metagraph_staking_fees_information $SNAPSHOT_FEES_STAKING_FILE_NAME $SNAPSHOT_FEES_STAKING_ALIAS $SNAPSHOT_FEES_STAKING_PASSWORD
 
   remote_start_metagraph
 
@@ -275,13 +290,26 @@ function remote-status() {
 # @arg layer!                 Layer name (global-l0, dag-l1, metagraph-l0, currency-l1, data-l1, monitoring)
 # @option -n                  Retroactive rows from logs file (default 10)
 function remote-logs() {
-  check_if_should_run_update
-
   build_paths
+  
+  check_if_should_run_update
   ensure_permissions_on_files_and_directories
   load_scripts
 
   remote_logs
+
+  exit 0
+}
+
+# @cmd Get the remote snapshot fee config
+function remote-snapshot-fee-config() {
+  build_paths
+  
+  check_if_should_run_update
+  ensure_permissions_on_files_and_directories
+  load_scripts
+
+  remote_snapshot_fee_config
 
   exit 0
 }
@@ -294,9 +322,9 @@ function update() {
   if [ -d "$SCRIPTS_PATH/hydra-operations" ]; then
     load_scripts
   fi
-  
+
   update_euclid
-  
+
   ensure_permissions_on_files_and_directories
 
   exit 0
@@ -326,7 +354,7 @@ function install-monitoring-service() {
 
   load_scripts
   ensure_permissions_on_files_and_directories
-  
+
   install_monitoring_service
 
   exit 0
@@ -342,7 +370,7 @@ function remote-deploy-monitoring-service() {
 
   load_scripts
   ensure_permissions_on_files_and_directories
-  
+
   remote_deploy_monitoring_service
 
   exit 0
@@ -359,7 +387,7 @@ function remote-start-monitoring-service() {
 
   load_scripts
   ensure_permissions_on_files_and_directories
-  
+
   remote_start_monitoring_service
 
   exit 0
@@ -385,6 +413,13 @@ function check_if_should_run_update() {
   local monitoring=$(jq -r '.deploy.ansible.monitoring // empty' "$ROOT_PATH/euclid.json")
   if [ -z "$monitoring" ]; then
     echo "$(tput setaf 3) Could not find the deploy.monitoring field on euclid.json file, the file is probably outdated. Running migrations..."
+    load_scripts
+    run_migrations
+  fi
+
+  local snapshot_fees=$(jq -r '.snapshot_fees // empty' "$ROOT_PATH/euclid.json")
+  if [ -z "$snapshot_fees" ]; then
+    echo "$(tput setaf 3) Could not find the snapshot_fees field on euclid.json file, the file is probably outdated. Running migrations..."
     load_scripts
     run_migrations
   fi
@@ -543,7 +578,7 @@ function update_euclid() {
   update_scripts
   update_remote_ansible_files
   update_local_ansible_files
-  
+
   if command -v run_migrations &>/dev/null; then
     run_migrations
   fi

--- a/scripts/hydra-operations/remote-deploy.sh
+++ b/scripts/hydra-operations/remote-deploy.sh
@@ -24,7 +24,13 @@ function remote_deploy_metagraph() {
   else
     force_genesis=false
   fi
-  
-  ansible-playbook -e "force_genesis=$force_genesis" -e "deploy_cl1=$deploy_cl1" -e "deploy_dl1=$deploy_dl1" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_DEPLOY_PLAYBOOK_FILE
-  
+
+  ansible-playbook \
+    -e "force_genesis=$force_genesis" \
+    -e "deploy_cl1=$deploy_cl1" \
+    -e "deploy_dl1=$deploy_dl1" \
+    -e "owner_p12_file_name=$SNAPSHOT_FEES_OWNER_FILE_NAME" \
+    -e "staking_p12_file_name=$SNAPSHOT_FEES_STAKING_FILE_NAME" \
+    -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_DEPLOY_PLAYBOOK_FILE
+
 }

--- a/scripts/hydra-operations/remote-snapshot-fee-config.sh
+++ b/scripts/hydra-operations/remote-snapshot-fee-config.sh
@@ -12,15 +12,41 @@ function fetch_latest_global_snapshot_metagraph_messages() {
   if [ "$http_code" -ne 200 ]; then
     echo_red "Failed to fetch data. HTTP Status Code: $http_code"
     exit 1
-  else  
+  else
     last_messages=$(echo "$response" | jq -r ".[1].lastCurrencySnapshots.\"$metagraph_id\".Right[1].lastMessages")
 
-    if [ -z "$last_messages" ]; then
-      echo_red "Failed when extracting the fee configuration from global snapshot"
+    if [ -z "$last_messages" ] || [ "$last_messages" = "null" ]; then
+      echo_red "Failed when extracting the fee configuration from global snapshot. Be sure your metagraph have the fees messages configured"
       exit 1
     else
       echo_green "Last messages extracted successfully:"
-      echo "$last_messages" | jq .
+
+      owner_address=$(echo "$last_messages" | jq -r .Owner.value.address)
+      owner_parent_ordinal=$(echo "$last_messages" | jq -r .Owner.value.parentOrdinal)
+      staking_address=$(echo "$last_messages" | jq -r .Staking.value.address)
+      staking_parent_ordinal=$(echo "$last_messages" | jq -r .Staking.value.parentOrdinal)
+
+      # Check if fields are empty or null and handle accordingly
+      if [ -z "$owner_address" ] || [ "$owner_address" = "null" ]; then
+        owner_address="N/A"
+      fi
+      if [ -z "$owner_parent_ordinal" ] || [ "$owner_parent_ordinal" = "null" ]; then
+        owner_parent_ordinal="N/A"
+      fi
+      if [ -z "$staking_address" ] || [ "$staking_address" = "null" ]; then
+        staking_address="N/A"
+      fi
+      if [ -z "$staking_parent_ordinal" ] || [ "$staking_parent_ordinal" = "null" ]; then
+        staking_parent_ordinal="N/A"
+      fi
+
+      echo_white "OWNER"
+      echo_url "Owner Address" "$owner_address"
+      echo_url "Owner Parent Ordinal" "$owner_parent_ordinal"
+      echo
+      echo_white "STAKING"
+      echo_url "Staking Address" "$staking_address"
+      echo_url "Staking Parent Ordinal" "$staking_parent_ordinal"
     fi
   fi
 

--- a/scripts/hydra-operations/remote-snapshot-fee-config.sh
+++ b/scripts/hydra-operations/remote-snapshot-fee-config.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+function fetch_latest_global_snapshot_metagraph_messages() {
+  local metagraph_id=$1
+  URL="http://$DEPLOY_NETWORK_HOST_IP:$DEPLOY_NETWORK_HOST_PUBLIC_PORT/global-snapshots/latest/combined" # Replace with your actual URL
+  HEADER="Content-Type: application/json"
+
+  echo_title "Fetching latest global snapshot from $URL"
+  response=$(curl -s -H "$HEADER" "$URL")
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" -H "$HEADER" "$URL")
+
+  if [ "$http_code" -ne 200 ]; then
+    echo_red "Failed to fetch data. HTTP Status Code: $http_code"
+    exit 1
+  else  
+    last_messages=$(echo "$response" | jq -r ".[1].lastCurrencySnapshots.\"$metagraph_id\".Right[1].lastMessages")
+
+    if [ -z "$last_messages" ]; then
+      echo_red "Failed when extracting the fee configuration from global snapshot"
+      exit 1
+    else
+      echo_green "Last messages extracted successfully:"
+      echo "$last_messages" | jq .
+    fi
+  fi
+
+}
+function remote_snapshot_fee_config() {
+  echo_title "################################## REMOTE SNAPSHOT FEE CONFIG ##################################"
+  echo_white
+
+  check_nodes_host_file
+  host=$(yq eval ".nodes.hosts.node-1.ansible_host" $ANSIBLE_HOSTS_FILE)
+  user=$(yq eval ".nodes.hosts.node-1.ansible_user" $ANSIBLE_HOSTS_FILE)
+  private_key=$(yq eval ".nodes.hosts.node-1.ansible_ssh_private_key_file" $ANSIBLE_HOSTS_FILE)
+
+  echo
+  echo_title "Fetching the metagraph-id in node $host"
+  echo_yellow "SSH to the node..."
+  local metagraph_id=$(ssh -i "$private_key" $user@$host "cd code/metagraph-l0; cat genesis.address")
+
+  if [ $? -ne 0 ]; then
+    echo_red "SSH command failed. Please check the connection and try again."
+    return 1
+  else
+    echo_green "Metagraph ID: $metagraph_id"
+    echo
+    fetch_latest_global_snapshot_metagraph_messages $metagraph_id
+  fi
+
+}

--- a/scripts/hydra-operations/remote-start.sh
+++ b/scripts/hydra-operations/remote-start.sh
@@ -15,6 +15,44 @@ function remote_start_metagraph() {
     force_genesis=false
   fi
 
-  ansible-playbook -e "force_genesis=$force_genesis" -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_START_PLAYBOOK_FILE
-  
+  if [ ! -z "$argc_force_owner_message" ]; then
+    force_owner_message=true
+  else
+    force_owner_message=false
+  fi
+
+  if [ ! -z "$argc_force_staking_message" ]; then
+    force_staking_message=true
+  else
+    force_staking_message=false
+  fi
+
+  # Validate owner parameters
+  if [ "$force_owner_message" = "true" ]; then
+    if [ -z "$SNAPSHOT_FEES_OWNER_FILE_NAME" ] || [ -z "$SNAPSHOT_FEES_OWNER_ALIAS" ] || [ -z "$SNAPSHOT_FEES_OWNER_PASSWORD" ]; then
+      echo "Error: When force_owner_message is set, you must provide owner_p12_file_name, owner_p12_alias, and owner_p12_password."
+      exit 1
+    fi
+  fi
+
+  # Validate staking parameters
+  if [ "$force_staking_message" = "true" ]; then
+    if [ -z "$SNAPSHOT_FEES_STAKING_FILE_NAME" ] || [ -z "$SNAPSHOT_FEES_STAKING_ALIAS" ] || [ -z "$SNAPSHOT_FEES_STAKING_PASSWORD" ]; then
+      echo "Error: When force_staking_message is set, you must provide staking_p12_file_name, staking_p12_alias, and staking_p12_password."
+      exit 1
+    fi
+  fi
+
+
+  ansible-playbook \
+    -e "force_genesis=$force_genesis" \
+    -e "force_owner_message=$force_owner_message" \
+    -e "force_staking_message=$force_staking_message" \
+    -e "owner_p12_file_name=$SNAPSHOT_FEES_OWNER_FILE_NAME" \
+    -e "owner_p12_alias=$SNAPSHOT_FEES_OWNER_ALIAS" \
+    -e "owner_p12_password=$SNAPSHOT_FEES_OWNER_PASSWORD" \
+    -e "staking_p12_file_name=$SNAPSHOT_FEES_STAKING_FILE_NAME" \
+    -e "staking_p12_alias=$SNAPSHOT_FEES_STAKING_ALIAS" \
+    -e "staking_p12_password=$SNAPSHOT_FEES_STAKING_PASSWORD" \
+    -i $ANSIBLE_HOSTS_FILE $ANSIBLE_NODES_START_PLAYBOOK_FILE
 }

--- a/scripts/migrations/migrations.sh
+++ b/scripts/migrations/migrations.sh
@@ -1,5 +1,11 @@
 function version_greater_than() {
-    [[ "$1" = "$(echo -e "$1\n$2" | sort -V | tail -n 1)" ]] && [[ "$1" != "$2" ]]
+    local version1="$1"
+    local version2="$2"
+    if [[ "$version1" = "$(echo -e "$version1\n$version2" | sort -V | tail -n 1)" ]] && [[ "$version1" != "$version2" ]]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 function run_migrations() {
@@ -9,6 +15,7 @@ function run_migrations() {
 
   CURRENT_VERSION=$(jq -r '.version // "0.0.0"' "$ROOT_PATH/euclid.json")
   CURRENT_VERSION_WITHOUT_V="${CURRENT_VERSION#v}"
+  echo_yellow "Current version: $CURRENT_VERSION_WITHOUT_V"
 
   if version_greater_than "0.9.0" $CURRENT_VERSION_WITHOUT_V; then
     echo "Running migration v0.9.0"
@@ -25,6 +32,15 @@ function run_migrations() {
     source ./migrations/v0.10.0.sh
     migrate_v_0_10_0
     current_version="0.10.0"
+    jq --arg current_version "$current_version" '.version = $current_version' $ROOT_PATH/euclid.json > $ROOT_PATH/temp.json && mv $ROOT_PATH/temp.json $ROOT_PATH/euclid.json
+  fi
+
+  if version_greater_than "0.11.0" $CURRENT_VERSION_WITHOUT_V; then
+    echo "Running migration v0.11.0"
+    cd $SCRIPTS_PATH
+    source ./migrations/v0.11.0.sh
+    migrate_v_0_11_0
+    current_version="0.11.0"
     jq --arg current_version "$current_version" '.version = $current_version' $ROOT_PATH/euclid.json > $ROOT_PATH/temp.json && mv $ROOT_PATH/temp.json $ROOT_PATH/euclid.json
   fi
 

--- a/scripts/migrations/v0.11.0.sh
+++ b/scripts/migrations/v0.11.0.sh
@@ -1,0 +1,23 @@
+function migrate_v_0_11_0() {
+  jq '.version = "0.11.0" |
+      . + { 
+        "snapshot_fees": {
+          "owner": {
+            "key_file": {
+              "name": "token-key.p12",
+              "alias": "token-key",
+              "password": "password"
+            }
+          },
+          "staking": {
+            "key_file": {
+              "name": "token-key-1.p12",
+              "alias": "token-key-1",
+              "password": "password"
+            }
+          }
+        }
+      }' "$ROOT_PATH/euclid.json" > "$ROOT_PATH/temp.json" && mv "$ROOT_PATH/temp.json" "$ROOT_PATH/euclid.json"
+
+  echo_green "Updated"
+}

--- a/scripts/utils/get-information.sh
+++ b/scripts/utils/get-information.sh
@@ -32,6 +32,14 @@ function get_env_variables_from_json_config_file() {
     export ANSIBLE_MONITORING_DEPLOY_PLAYBOOK_FILE=$(jq -r .deploy.ansible.monitoring.playbooks.deploy $ROOT_PATH/euclid.json)
     export ANSIBLE_MONITORING_START_PLAYBOOK_FILE=$(jq -r .deploy.ansible.monitoring.playbooks.start $ROOT_PATH/euclid.json)
 
+    export SNAPSHOT_FEES_OWNER_FILE_NAME=$(jq -r .snapshot_fees.owner.key_file.name $ROOT_PATH/euclid.json)
+    export SNAPSHOT_FEES_OWNER_ALIAS=$(jq -r .snapshot_fees.owner.key_file.alias $ROOT_PATH/euclid.json)
+    export SNAPSHOT_FEES_OWNER_PASSWORD=$(jq -r .snapshot_fees.owner.key_file.password $ROOT_PATH/euclid.json)
+
+    export SNAPSHOT_FEES_STAKING_FILE_NAME=$(jq -r .snapshot_fees.staking.key_file.name $ROOT_PATH/euclid.json)
+    export SNAPSHOT_FEES_STAKING_ALIAS=$(jq -r .snapshot_fees.staking.key_file.alias $ROOT_PATH/euclid.json)
+    export SNAPSHOT_FEES_STAKING_PASSWORD=$(jq -r .snapshot_fees.staking.key_file.password $ROOT_PATH/euclid.json)
+
     ## Colors
     export OUTPUT_RED=$(tput setaf 1)
     export OUTPUT_GREEN=$(tput setaf 2)

--- a/scripts/utils/validations.sh
+++ b/scripts/utils/validations.sh
@@ -205,3 +205,78 @@ function check_if_genesis_files_exists() {
         exit 1
     fi
 }
+
+function check_metagraph_owner_fees_file_exists() {
+    if [ "$#" -eq 0 ]; then
+        return
+    fi
+    local owner_file_path=$SOURCE_PATH/p12-files/$1
+    if [ -f "$owner_file_path" ]; then
+        if [[ "$owner_file_path" == *.p12 ]]; then
+            echo_green "Owner file exists"
+        else
+            echo_red "Invalid owner file extension, it should be .p12"
+            exit 1
+        fi
+    else
+        echo_red "Owner file does not exist."
+        exit 1
+    fi
+}
+
+function check_metagraph_staking_fees_file_exists() {
+    if [ "$#" -eq 0 ]; then
+        return
+    fi
+    local staking_file_path=$SOURCE_PATH/p12-files/$1
+    if [ -f "$staking_file_path" ]; then
+        if [[ "$staking_file_path" == *.p12 ]]; then
+            echo_green "Staking file exists"
+        else
+            echo_red "Invalid staking file extension, it should be .p12"
+            exit 1
+        fi
+    else
+        echo_red "Staking file does not exist."
+        exit 1
+    fi
+}
+
+function check_metagraph_owner_fees_information() {
+    if [ "$#" -eq 0 ]; then
+        return
+    elif [ "$#" -ne 3 ]; then
+        echo_red "You should provide all 3 parameters to owner wallet validation"
+        exit 1
+    fi
+}
+
+function check_metagraph_staking_fees_information() {
+    if [ "$#" -eq 0 ]; then
+        return
+    elif [ "$#" -ne 3 ]; then
+        echo_red "You should provide all 3 parameters to staking wallet validation"
+        exit 1
+    fi
+}
+
+function check_if_owner_and_staking_address_are_equal() {
+    if [[ "$SNAPSHOT_FEES_OWNER_FILE_NAME" == "$SNAPSHOT_FEES_STAKING_FILE_NAME" ]]; then
+        echo_red "Owner and Staking address should be different"
+        exit 1
+    fi
+}
+
+function confirm_force_genesis() {
+    if [[ -z "$argc_force_genesis" ]]; then
+        return
+    fi
+    echo_yellow "This operation will delete your metagraph and snapshots"
+    read -p "Do you want to continue? (Y/y to confirm): " -r response
+
+    echo_white ""
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
+        echo "Aborting"
+        exit 1
+    fi
+}


### PR DESCRIPTION
### Changes
+ Updating `remote-deploy` and `remote-start` functions to send the snapshot fees messages automatically when deploying metagraphs through Euclid
+ Updating the README file
+ Updated the Ansible playbooks