### PR TITLE
Adding tessellation branch running type

### DIFF
--- a/euclid.json
+++ b/euclid.json
@@ -1,14 +1,15 @@
 {
   "github_token": "",
   "version": "0.12.0-SNAPSHOT",
-  "tessellation_version": "2.3.3",
+  "tessellation_version": "2.8.0",
+  "ref_type": "tag",
   "project_name": "custom-project",
   "framework": {
     "name": "currency",
     "modules": [
       "data"
     ],
-    "version": "v2.3.3",
+    "version": "v2.8.0",
     "ref_type": "tag"
   },
   "layers": [

--- a/infra/ansible/local/playbooks/start/containers/nodes.ansible.yml
+++ b/infra/ansible/local/playbooks/start/containers/nodes.ansible.yml
@@ -24,6 +24,7 @@
         name: "{{ node_info.name }}"
         image: metagraph-base-image:latest
         state: started
+        platform: linux/amd64
         networks:
         - name: custom-network
           ipv4_address: "{{ base_prefix_ip }}{{ (index + 1) * offset }}"
@@ -54,3 +55,4 @@
       loop_control:
         loop_var: node_info
         index_var: index
+      no_log: true

--- a/infra/ansible/local/playbooks/start/containers/nodes.ansible.yml
+++ b/infra/ansible/local/playbooks/start/containers/nodes.ansible.yml
@@ -24,7 +24,6 @@
         name: "{{ node_info.name }}"
         image: metagraph-base-image:latest
         state: started
-        platform: linux/amd64
         networks:
         - name: custom-network
           ipv4_address: "{{ base_prefix_ip }}{{ (index + 1) * offset }}"
@@ -55,4 +54,3 @@
       loop_control:
         loop_var: node_info
         index_var: index
-      no_log: true

--- a/infra/docker/metagraph-base-image/Dockerfile
+++ b/infra/docker/metagraph-base-image/Dockerfile
@@ -1,6 +1,6 @@
-ARG TESSELLATION_VERSION
+ARG TESSELLATION_VERSION_NAME
 
-FROM --platform=linux/amd64 metagraph-ubuntu-${TESSELLATION_VERSION}
+FROM metagraph-ubuntu-${TESSELLATION_VERSION_NAME}
 
 ARG SHOULD_BUILD_GLOBAL_L0
 ARG SHOULD_BUILD_DAG_L1
@@ -17,59 +17,63 @@ COPY project/$TEMPLATE_NAME $TEMPLATE_NAME
 COPY global-l0/genesis/genesis.csv global-genesis.csv
 COPY metagraph-l0/genesis/genesis.csv metagraph-genesis.csv
 
-RUN mkdir shared_jars
-RUN mkdir shared_genesis
+RUN mkdir shared_jars && mkdir shared_genesis
 
-RUN if [ "$SHOULD_BUILD_GLOBAL_L0" = "true" ]; then \
-        mkdir global-l0; \
-        cp global-l0.jar global-l0/global-l0.jar; \
-        cp cl-wallet.jar global-l0/cl-wallet.jar; \
-        cp cl-keytool.jar global-l0/cl-keytool.jar; \
+RUN set -e; \
+    if [ "$SHOULD_BUILD_GLOBAL_L0" = "true" ]; then \
+        mkdir global-l0 && \
+        cp global-l0.jar global-l0/global-l0.jar && \
+        cp cl-wallet.jar global-l0/cl-wallet.jar && \
+        cp cl-keytool.jar global-l0/cl-keytool.jar && \
         mv global-genesis.csv global-l0/genesis.csv; \
     fi
 
-RUN if [ "$SHOULD_BUILD_DAG_L1" = "true" ]; then \
-        mkdir dag-l1; \
-        cp dag-l1.jar dag-l1/dag-l1.jar; \
-        cp cl-wallet.jar dag-l1/cl-wallet.jar; \
+RUN set -e; \
+    if [ "$SHOULD_BUILD_DAG_L1" = "true" ]; then \
+        mkdir dag-l1 && \
+        cp dag-l1.jar dag-l1/dag-l1.jar && \
+        cp cl-wallet.jar dag-l1/cl-wallet.jar && \
         cp cl-keytool.jar dag-l1/cl-keytool.jar; \
     fi
 
-RUN if [ "$SHOULD_BUILD_METAGRAPH_L0" = "true" ]; then \
-        mkdir metagraph-l0; \
-        cp cl-wallet.jar metagraph-l0/cl-wallet.jar; \
-        cp cl-keytool.jar metagraph-l0/cl-keytool.jar; \
-        rm -r -f $TEMPLATE_NAME/modules/l0/target; \
-        cd $TEMPLATE_NAME; \
-        sbt currencyL0/assembly; \
-        cd ..; \
-        mv $TEMPLATE_NAME/modules/l0/target/scala-2.13/*.jar metagraph-l0/metagraph-l0.jar; \
-        mv metagraph-genesis.csv metagraph-l0/genesis.csv; \
-        cp metagraph-l0/metagraph-l0.jar shared_jars/metagraph-l0.jar; \
+RUN set -e; \
+    if [ "$SHOULD_BUILD_METAGRAPH_L0" = "true" ]; then \
+        mkdir metagraph-l0 && \
+        cp cl-wallet.jar metagraph-l0/cl-wallet.jar && \
+        cp cl-keytool.jar metagraph-l0/cl-keytool.jar && \
+        rm -r -f $TEMPLATE_NAME/modules/l0/target && \
+        cd $TEMPLATE_NAME && \
+        sbt currencyL0/assembly && \
+        cd .. && \
+        mv $TEMPLATE_NAME/modules/l0/target/scala-2.13/*.jar metagraph-l0/metagraph-l0.jar && \
+        mv metagraph-genesis.csv metagraph-l0/genesis.csv && \
+        cp metagraph-l0/metagraph-l0.jar shared_jars/metagraph-l0.jar && \
         cp metagraph-l0/genesis.csv shared_genesis/genesis.csv; \
     fi
 
-RUN if [ "$SHOULD_BUILD_CURRENCY_L1" = "true" ]; then \
-        mkdir currency-l1; \
-        cp cl-wallet.jar currency-l1/cl-wallet.jar; \
-        cp cl-keytool.jar currency-l1/cl-keytool.jar; \
-        rm -r -f $TEMPLATE_NAME/modules/l1/target; \
-        cd $TEMPLATE_NAME; \
-        sbt currencyL1/assembly; \
-        cd ..; \
-        mv $TEMPLATE_NAME/modules/l1/target/scala-2.13/*.jar currency-l1/currency-l1.jar; \
+RUN set -e; \
+    if [ "$SHOULD_BUILD_CURRENCY_L1" = "true" ]; then \
+        mkdir currency-l1 && \
+        cp cl-wallet.jar currency-l1/cl-wallet.jar && \
+        cp cl-keytool.jar currency-l1/cl-keytool.jar && \
+        rm -r -f $TEMPLATE_NAME/modules/l1/target && \
+        cd $TEMPLATE_NAME && \
+        sbt currencyL1/assembly && \
+        cd .. && \
+        mv $TEMPLATE_NAME/modules/l1/target/scala-2.13/*.jar currency-l1/currency-l1.jar && \
         cp currency-l1/currency-l1.jar shared_jars/currency-l1.jar; \
     fi
 
-RUN if [ "$SHOULD_BUILD_DATA_L1" = "true" ]; then \
-        mkdir data-l1; \
-        cp cl-wallet.jar data-l1/cl-wallet.jar; \
-        cp cl-keytool.jar data-l1/cl-keytool.jar; \
-        rm -r -f $TEMPLATE_NAME/modules/data_l1/target; \
-        cd $TEMPLATE_NAME; \
-        sbt dataL1/assembly; \
-        cd ..; \
-        mv $TEMPLATE_NAME/modules/data_l1/target/scala-2.13/*.jar data-l1/data-l1.jar; \
+RUN set -e; \
+    if [ "$SHOULD_BUILD_DATA_L1" = "true" ]; then \
+        mkdir data-l1 && \
+        cp cl-wallet.jar data-l1/cl-wallet.jar && \
+        cp cl-keytool.jar data-l1/cl-keytool.jar && \
+        rm -r -f $TEMPLATE_NAME/modules/data_l1/target && \
+        cd $TEMPLATE_NAME && \
+        sbt dataL1/assembly && \
+        cd .. && \
+        mv $TEMPLATE_NAME/modules/data_l1/target/scala-2.13/*.jar data-l1/data-l1.jar && \
         cp data-l1/data-l1.jar shared_jars/data-l1.jar; \
     fi
 
@@ -80,6 +84,6 @@ RUN rm -r -f cl-keytool.jar && \
     rm -r -f global-genesis.csv && \
     rm -r -f metagraph-genesis.csv && \
     rm -r -f tessellation && \
-    rm -r -f $TEMPLATE_NAME 
-    
+    rm -r -f $TEMPLATE_NAME
+
 CMD ["sh", "-c", "while true; do sleep 86400; done"]

--- a/infra/docker/metagraph-base-image/docker-compose.yml
+++ b/infra/docker/metagraph-base-image/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 services:
   metagraph-base-image:
-    platform: linux/amd64
     image: "metagraph-base-image"
     build:
       context: ../../../source

--- a/infra/docker/metagraph-ubuntu/Dockerfile
+++ b/infra/docker/metagraph-ubuntu/Dockerfile
@@ -1,9 +1,10 @@
-FROM --platform=linux/amd64 ubuntu:20.04
+FROM ubuntu:20.04
 
 WORKDIR "/code"
 
 ARG GIT_PERSONAL_ACCESS_TOKEN
 ARG TESSELLATION_VERSION
+ARG TESSELLATION_VERSION_SEMVER
 ARG CHECKOUT_TESSELLATION_VERSION
 ARG SHOULD_USE_UPDATED_MODULES
 
@@ -27,7 +28,7 @@ RUN git clone https://github.com/Constellation-Labs/tessellation.git && \
     cd tessellation && \
     git checkout $CHECKOUT_TESSELLATION_VERSION && \
     rm -r version.sbt && \
-    echo "ThisBuild / version := \"$TESSELLATION_VERSION\"" > version.sbt
+    echo "ThisBuild / version := \"$TESSELLATION_VERSION_SEMVER\"" > version.sbt
     
 RUN cd tessellation && \
     if [ "$SHOULD_USE_UPDATED_MODULES" = "true" ]; then \

--- a/infra/docker/metagraph-ubuntu/docker-compose.yml
+++ b/infra/docker/metagraph-ubuntu/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '3'
 services:
   metagraph-ubuntu:
-    platform: linux/amd64
     build: .
-    image: "metagraph-ubuntu-${TESSELLATION_VERSION}"
+    image: "metagraph-ubuntu-${TESSELLATION_VERSION_NAME}"

--- a/scripts/hydra
+++ b/scripts/hydra
@@ -110,6 +110,7 @@ function build() {
 
   set_docker_compose
   check_if_docker_is_running
+  check_git_ref_exists $TESSELLATION_VERSION
 
   build_containers
 
@@ -420,6 +421,13 @@ function check_if_should_run_update() {
   local snapshot_fees=$(jq -r '.snapshot_fees // empty' "$ROOT_PATH/euclid.json")
   if [ -z "$snapshot_fees" ]; then
     echo "$(tput setaf 3) Could not find the snapshot_fees field on euclid.json file, the file is probably outdated. Running migrations..."
+    load_scripts
+    run_migrations
+  fi
+
+  local ref_type=$(jq -r '.ref_type // empty' "$ROOT_PATH/euclid.json")
+  if [ -z "$ref_type" ]; then
+    echo "$(tput setaf 3) Could not find the ref_type field on euclid.json file, the file is probably outdated. Running migrations..."
     load_scripts
     run_migrations
   fi

--- a/scripts/hydra-operations/build.sh
+++ b/scripts/hydra-operations/build.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 
 function build_metagraph_ubuntu() {
-  if [[ -z "$(docker images -q metagraph-ubuntu-${TESSELLATION_VERSION})" ]]; then
+  if [[ -z "$(docker images -q metagraph-ubuntu-${TESSELLATION_VERSION_NAME})" ]]; then
     echo
     echo
-    echo_white "Building metagraph ubuntu for tessellation $TESSELLATION_VERSION"
+    echo_white "Building metagraph ubuntu for tessellation $TESSELLATION_VERSION in image name metagraph-ubuntu-$TESSELLATION_VERSION_NAME"
     cd $INFRA_PATH/docker/metagraph-ubuntu
 
     CHECKOUT_TESSELLATION_VERSION=$(get_checkout_tessellation_version "$TESSELLATION_VERSION")
     SHOULD_USE_UPDATED_MODULES=$(get_should_use_updated_modules "$TESSELLATION_VERSION")
+
     if [ ! -z "$argc_no_cache" ]; then
       $DOCKER_COMPOSE build \
         --build-arg GIT_PERSONAL_ACCESS_TOKEN=$GITHUB_TOKEN \
         --build-arg TESSELLATION_VERSION=$TESSELLATION_VERSION \
+        --build-arg TESSELLATION_VERSION_SEMVER=$TESSELLATION_VERSION_SEMVER \
         --build-arg CHECKOUT_TESSELLATION_VERSION=$CHECKOUT_TESSELLATION_VERSION \
         --build-arg SHOULD_USE_UPDATED_MODULES=$SHOULD_USE_UPDATED_MODULES \
         --no-cache
@@ -20,9 +22,11 @@ function build_metagraph_ubuntu() {
       $DOCKER_COMPOSE build \
         --build-arg GIT_PERSONAL_ACCESS_TOKEN=$GITHUB_TOKEN \
         --build-arg TESSELLATION_VERSION=$TESSELLATION_VERSION \
+        --build-arg TESSELLATION_VERSION_SEMVER=$TESSELLATION_VERSION_SEMVER \
         --build-arg CHECKOUT_TESSELLATION_VERSION=$CHECKOUT_TESSELLATION_VERSION \
         --build-arg SHOULD_USE_UPDATED_MODULES=$SHOULD_USE_UPDATED_MODULES
     fi
+    
     echo_green "Ubuntu for tessellation $TESSELLATION_VERSION built"
   else
     echo_green "Ubuntu for tessellation $TESSELLATION_VERSION already built, skipping..."
@@ -78,7 +82,7 @@ function build_metagraph_base_image() {
 
   if [ ! -z "$argc_no_cache" ]; then
     $DOCKER_COMPOSE build \
-      --build-arg TESSELLATION_VERSION=$TESSELLATION_VERSION \
+      --build-arg TESSELLATION_VERSION_NAME=$TESSELLATION_VERSION_NAME \
       --build-arg TEMPLATE_NAME=$PROJECT_NAME \
       --build-arg SHOULD_BUILD_GLOBAL_L0=$should_build_global_l0 \
       --build-arg SHOULD_BUILD_DAG_L1=$should_build_dag_l1 \
@@ -88,7 +92,7 @@ function build_metagraph_base_image() {
       --no-cache
   else
     $DOCKER_COMPOSE build \
-      --build-arg TESSELLATION_VERSION=$TESSELLATION_VERSION \
+      --build-arg TESSELLATION_VERSION_NAME=$TESSELLATION_VERSION_NAME \
       --build-arg TEMPLATE_NAME=$PROJECT_NAME \
       --build-arg SHOULD_BUILD_GLOBAL_L0=$should_build_global_l0 \
       --build-arg SHOULD_BUILD_DAG_L1=$should_build_dag_l1 \

--- a/scripts/hydra-operations/destroy.sh
+++ b/scripts/hydra-operations/destroy.sh
@@ -18,7 +18,7 @@ function destroy_containers() {
 
     echo_white "Trying to destroy container grafana ..."
     if docker inspect grafana &>/dev/null; then
-        docker rm -f $name
+        docker rm -f grafana
         echo_green "Container grafana removed successfully."
     else
         echo_yellow "Container grafana does not exist."
@@ -29,7 +29,7 @@ function destroy_containers() {
 
     echo_white "Trying to destroy container prometheus ..."
     if docker inspect prometheus &>/dev/null; then
-        docker rm -f $name
+        docker rm -f prometheus
         echo_green "Container prometheus removed successfully."
     else
         echo_yellow "Container prometheus does not exist."

--- a/scripts/hydra-operations/start.sh
+++ b/scripts/hydra-operations/start.sh
@@ -184,6 +184,12 @@ function print_nodes_information() {
         ((index++))
     done < <(jq -c '.[]' <<<"$NODES")
 
+    if [[ "$START_GRAFANA_CONTAINER" == "true" ]]; then
+        echo_green "Telemetry"
+        echo_url "Grafana:" "http://localhost:3000"
+        echo
+    fi
+
     echo_green "Clusters URLs"
     if [[ " ${LAYERS[*]} " =~ "global-l0" ]]; then
         raw_port=$(yq eval '.base_global_l0_public_port' $ansible_vars_path)

--- a/scripts/migrations/migrations.sh
+++ b/scripts/migrations/migrations.sh
@@ -44,6 +44,15 @@ function run_migrations() {
     jq --arg current_version "$current_version" '.version = $current_version' $ROOT_PATH/euclid.json > $ROOT_PATH/temp.json && mv $ROOT_PATH/temp.json $ROOT_PATH/euclid.json
   fi
 
+  if version_greater_than "0.12.0" $CURRENT_VERSION_WITHOUT_V; then
+    echo "Running migration v0.12.0"
+    cd $SCRIPTS_PATH
+    source ./migrations/v0.12.0.sh
+    migrate_v_0_12_0
+    current_version="0.12.0"
+    jq --arg current_version "$current_version" '.version = $current_version' $ROOT_PATH/euclid.json > $ROOT_PATH/temp.json && mv $ROOT_PATH/temp.json $ROOT_PATH/euclid.json
+  fi
+
   echo "migrations finished..."
   echo
 }

--- a/scripts/migrations/v0.12.0.sh
+++ b/scripts/migrations/v0.12.0.sh
@@ -1,0 +1,8 @@
+function migrate_v_0_12_0() {
+  jq '.version = "0.12.0" |
+      . + { 
+        "ref_type": "tag"
+      }' "$ROOT_PATH/euclid.json" > "$ROOT_PATH/temp.json" && mv "$ROOT_PATH/temp.json" "$ROOT_PATH/euclid.json"
+
+  echo_green "v0.12.0 Updated"
+}


### PR DESCRIPTION
### Changes
+ Updated euclid.json to include the new file: `ref_type`. This field accepts: tag or branch
+ Updated in euclid.json the default tessellation_version and framework version to 2.8.0
+ Removed unnecessary --platform=linux/amd64
+ Updated metagraph-base-image Dockerfile to handle with errors
+ Adding v0.12.0 migration
+ Adding telemetry URL information when starting
+ Fixing destroying to also destroy telemetry containers