### PR TITLE
add migration to cleanup `github_token` from `euclid.json`

### DIFF
--- a/scripts/migrations/migrations.sh
+++ b/scripts/migrations/migrations.sh
@@ -52,7 +52,16 @@ function run_migrations() {
     current_version="0.12.0"
     jq --arg current_version "$current_version" '.version = $current_version' $ROOT_PATH/euclid.json > $ROOT_PATH/temp.json && mv $ROOT_PATH/temp.json $ROOT_PATH/euclid.json
   fi
-  
+
+  if version_greater_than "0.18.0" $CURRENT_VERSION_WITHOUT_V; then
+    echo "Running migration v0.18.0"
+    cd $SCRIPTS_PATH
+    source ./migrations/v0.18.0.sh
+    migrate_v_0_18_0
+    current_version="0.18.0"
+    jq --arg current_version "$current_version" '.version = $current_version' $ROOT_PATH/euclid.json > $ROOT_PATH/temp.json && mv $ROOT_PATH/temp.json $ROOT_PATH/euclid.json
+  fi
+
   echo "migrations finished..."
   echo
 }

--- a/scripts/migrations/v0.18.0.sh
+++ b/scripts/migrations/v0.18.0.sh
@@ -1,0 +1,6 @@
+function migrate_v_0_18_0() {
+  jq '.version = "0.18.0" |
+      del(.github_token)' "$ROOT_PATH/euclid.json" > "$ROOT_PATH/temp.json" && mv "$ROOT_PATH/temp.json" "$ROOT_PATH/euclid.json"
+
+  echo_green "v0.18.0 Updated - Removed github_token"
+}


### PR DESCRIPTION
following https://github.com/Constellation-Labs/euclid-development-environment/pull/67

adding a migration to remove the `github_token` field from the `euclid.json` when doing `hydra update`, to prevent confusion for end-users.