### PR TITLE
Copy jars from container on `hydra build` command as well.

### DIFF
--- a/scripts/hydra-operations/build.sh
+++ b/scripts/hydra-operations/build.sh
@@ -115,6 +115,20 @@ function build_metagraph_base_image() {
   fi
 
   echo_green "Metagraph base image built"
+
+  copy_jars_from_image
+}
+
+function copy_jars_from_image() {
+  echo_white "Copying jars to infra/shared/jars..."
+
+  # Create temporary container from the base image, to copy jars from
+  local container_id=$(docker create metagraph-base-image)
+
+  docker cp "$container_id:/code/shared_jars/." "$INFRA_PATH/shared/jars/"
+  docker rm "$container_id" > /dev/null
+
+  echo_green "Jars copied to infra/shared/jars"
 }
 
 function build_containers() {


### PR DESCRIPTION
Now, these jars only get copied when doing `start-genesis` locally, and those jars are being used when doing `hydra remote-deploy`. 

I think it's better we copy the jars after doing `hydra build` already to `infra/shared/jars`, to be able to right away execute `hydra remote-deploy` without needing to start the whole cluster locally with genesis again (a step easily missed)?