### PR TITLE
Add option to fetch precompiled tessellation

### DIFF
--- a/infra/metagraph-base-image/docker-compose.yml
+++ b/infra/metagraph-base-image/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   metagraph-base-image:
     image: "metagraph-base-image"

--- a/infra/metagraph-ubuntu/Dockerfile
+++ b/infra/metagraph-ubuntu/Dockerfile
@@ -21,15 +21,23 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
-    git clone https://github.com/Constellation-Labs/tessellation.git; \
-    cd tessellation; \
-    git checkout "$CHECKOUT_TESSELLATION_VERSION"; \
-    if [ "$TESSELLATION_VERSION_IS_TAG_OR_BRANCH" = "branch" ]; then \
-      export RELEASE_TAG=99.99.99; \
-      sbt -Dversion.override=99.99.99 sdk/publishM2; \
-    fi; \
-    sbt wallet/assembly dagL1/assembly keytool/assembly dagL0/assembly; \
-    mv modules/wallet/target/scala-2.13/tessellation-wallet-assembly-* /code/cl-wallet.jar; \
-    mv modules/keytool/target/scala-2.13/tessellation-keytool-assembly-* /code/cl-keytool.jar; \
-    mv modules/dag-l1/target/scala-2.13/tessellation-dag-l1-assembly-* /code/dag-l1.jar; \
-    mv modules/dag-l0/target/scala-2.13/tessellation-dag-l0-assembly-* /code/global-l0.jar
+    if [ "$TESSELLATION_VERSION_IS_TAG_OR_BRANCH" = "tag" ]; then \
+        BASE_URL="https://github.com/Constellation-Labs/tessellation/releases/download/${CHECKOUT_TESSELLATION_VERSION}"; \
+        curl -f -L -o cl-wallet.jar "${BASE_URL}/cl-wallet.jar"; \
+        curl -f -L -o cl-keytool.jar "${BASE_URL}/cl-keytool.jar"; \
+        curl -f -L -o dag-l1.jar "${BASE_URL}/cl-dag-l1.jar"; \
+        curl -f -L -o global-l0.jar "${BASE_URL}/cl-node.jar"; \
+    else \
+        git clone https://github.com/Constellation-Labs/tessellation.git; \
+        cd tessellation; \
+        git checkout "$CHECKOUT_TESSELLATION_VERSION" || exit 1; \
+        if [ "$TESSELLATION_VERSION_IS_TAG_OR_BRANCH" = "branch" ]; then \
+        export RELEASE_TAG=99.99.99; \
+        sbt -Dversion.override=99.99.99 sdk/publishM2; \
+        fi; \
+        sbt wallet/assembly dagL1/assembly keytool/assembly dagL0/assembly; \
+        mv modules/wallet/target/scala-2.13/tessellation-wallet-assembly-* /code/cl-wallet.jar; \
+        mv modules/keytool/target/scala-2.13/tessellation-keytool-assembly-* /code/cl-keytool.jar; \
+        mv modules/dag-l1/target/scala-2.13/tessellation-dag-l1-assembly-* /code/dag-l1.jar; \
+        mv modules/dag-l0/target/scala-2.13/tessellation-dag-l0-assembly-* /code/global-l0.jar; \
+    fi

--- a/infra/metagraph-ubuntu/docker-compose.yml
+++ b/infra/metagraph-ubuntu/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   metagraph-ubuntu:
     build: .

--- a/scripts/template/custom-template.sh
+++ b/scripts/template/custom-template.sh
@@ -18,15 +18,15 @@ function create_template() {
         
         if [ "$TEMPLATE_VERSION_IS_TAG_OR_BRANCH" == "tag" ]; then
             if [[ " ${FRAMEWORK_MODULES[*]} " =~ "data" ]]; then
-                g8 Constellation-Labs/currency --tag $TEMPLATE_VERSION --name="$PROJECT_NAME" --tessellation_version="$TESSELLATION_VERSION" --include_data_l1="yes"
+                g8 Constellation-Labs/currency --tag $TEMPLATE_VERSION --name="$PROJECT_NAME" --tessellation_version="$TESSELLATION_VERSION_SEMVER" --include_data_l1="yes"
             else
-                g8 Constellation-Labs/currency --tag $TEMPLATE_VERSION --name="$PROJECT_NAME" --tessellation_version="$TESSELLATION_VERSION"
+                g8 Constellation-Labs/currency --tag $TEMPLATE_VERSION --name="$PROJECT_NAME" --tessellation_version="$TESSELLATION_VERSION_SEMVER"
             fi
         else
             if [[ " ${FRAMEWORK_MODULES[*]} " =~ "data" ]]; then
-                g8 Constellation-Labs/currency --branch $TEMPLATE_VERSION --name="$PROJECT_NAME" --tessellation_version="$TESSELLATION_VERSION" --include_data_l1="yes"
+                g8 Constellation-Labs/currency --branch $TEMPLATE_VERSION --name="$PROJECT_NAME" --tessellation_version="$TESSELLATION_VERSION_SEMVER" --include_data_l1="yes"
             else
-                g8 Constellation-Labs/currency --branch $TEMPLATE_VERSION --name="$PROJECT_NAME" --tessellation_version="$TESSELLATION_VERSION"
+                g8 Constellation-Labs/currency --branch $TEMPLATE_VERSION --name="$PROJECT_NAME" --tessellation_version="$TESSELLATION_VERSION_SEMVER"
             fi
         fi
         


### PR DESCRIPTION
With these changes, devs can choose in `euclid.json` the `tessellation_version` they want to use and it will be downloaded straight from Github releases and put inside the docker image that is used for building the metagraph.

It seems tessellation dependency will get downloaded from maven etc. already anyway, so it's just the binaries. 

Also I left the option for devs to choose a custom built tessellation version, by changing the `"ref_type": "tag"` to branch which will get a certain branch of tessellation and compile/publish inside the docker container as version `99.99.99` as before.