### PR TITLE
update to use tessellation 4.0.0-rc.0

### DIFF
--- a/euclid.json
+++ b/euclid.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.18.0",
-  "tessellation_version": "3.5.8",
+  "version": "0.19.0",
+  "tessellation_version": "4.0.0-rc.0",
   "ref_type": "tag",
   "project_name": "custom-project",
   "framework": {
@@ -8,7 +8,7 @@
     "modules": [
       "data"
     ],
-    "version": "v3.5.0",
+    "version": "v3.6.0",
     "ref_type": "tag"
   },
   "layers": [

--- a/infra/ansible/remote/nodes/playbooks/deploy/configure.ansible.yml
+++ b/infra/ansible/remote/nodes/playbooks/deploy/configure.ansible.yml
@@ -8,9 +8,9 @@
       apt:
         update_cache: yes
 
-    - name: Install Java OpenJDK 11
+    - name: Install Java OpenJDK 21
       apt:
-        name: openjdk-11-jdk
+        name: openjdk-21-jre
         state: present
 
     - name: Install curl

--- a/infra/metagraph-ubuntu/Dockerfile
+++ b/infra/metagraph-ubuntu/Dockerfile
@@ -12,7 +12,7 @@ ENV LC_ALL=C.UTF-8 \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      openjdk-11-jdk curl gnupg lsof ca-certificates git && \
+      openjdk-21-jre curl gnupg lsof ca-certificates git && \
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
     curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add - && \


### PR DESCRIPTION
requires https://github.com/Constellation-Labs/currency.g8/pull/16 

updating euclid to use tessellation `4.0.0-rc.0` by default, for use on intNet. Also making sure Java 21 and Scala 2.13.6 work.