### PR TITLE
improve git flow after install

### DIFF
--- a/scripts/hydra-operations/install-template.sh
+++ b/scripts/hydra-operations/install-template.sh
@@ -85,6 +85,67 @@ function install_template() {
     rm -r .git
   fi
 
+  cat > .gitignore << 'GITIGNORE'
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+
+# Scala build artifacts
+.metals/
+.bloop/
+.bsp/
+.scala-build/
+target/
+metals.sbt
+**/metals.sbt
+project/metals.sbt
+project/project/metals.sbt
+.scalafmt-cache
+.scalafix-cache
+
+# Node
+node_modules/
+
+# Jars (downloaded during build)
+infra/shared/jars/*.jar
+
+# Genesis files (generated)
+source/metagraph-l0/genesis/genesis.address
+source/metagraph-l0/genesis/genesis.snapshot
+infra/shared/genesis/*
+
+# Grafana data
+infra/grafana/grafana/config/
+infra/grafana/prometheus/data/
+infra/grafana/prometheus/monitoring/
+
+# Monitoring service
+source/*-monitoring-service/node_modules
+source/*-monitoring-service/config/config.json
+source/*-monitoring-service/config/id_monitoring
+
+# Shared data (generated at runtime)
+infra/shared/data/*
+!infra/shared/data/.gitkeep
+
+# Project config (contains p12 passwords)
+euclid.json
+
+# Private key files
+source/p12-files/*
+!source/p12-files/.gitkeep
+GITIGNORE
+
+  git init
+  git add -A
+  git commit -m "Initial commit after hydra install-template ($argc_name)"
+
   echo_green ""
   echo_url "Template installed: " $argc_name
 }

--- a/scripts/hydra-operations/install.sh
+++ b/scripts/hydra-operations/install.sh
@@ -12,6 +12,67 @@ function install_project() {
     rm -r .git
   fi
 
+  cat > .gitignore << 'GITIGNORE'
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+
+# Scala build artifacts
+.metals/
+.bloop/
+.bsp/
+.scala-build/
+target/
+metals.sbt
+**/metals.sbt
+project/metals.sbt
+project/project/metals.sbt
+.scalafmt-cache
+.scalafix-cache
+
+# Node
+node_modules/
+
+# Jars (downloaded during build)
+infra/shared/jars/*.jar
+
+# Genesis files (generated)
+source/metagraph-l0/genesis/genesis.address
+source/metagraph-l0/genesis/genesis.snapshot
+infra/shared/genesis/*
+
+# Grafana data
+infra/grafana/grafana/config/
+infra/grafana/prometheus/data/
+infra/grafana/prometheus/monitoring/
+
+# Monitoring service
+source/*-monitoring-service/node_modules
+source/*-monitoring-service/config/config.json
+source/*-monitoring-service/config/id_monitoring
+
+# Shared data (generated at runtime)
+infra/shared/data/*
+!infra/shared/data/.gitkeep
+
+# Project config (contains p12 passwords)
+euclid.json
+
+# Private key files
+source/p12-files/*
+!source/p12-files/.gitkeep
+GITIGNORE
+
+  git init
+  git add -A
+  git commit -m "Initial commit after hydra install"
+
   echo_green "Installed"
   
 }


### PR DESCRIPTION
When doing `hydra install`, the user ends up with an empty untracked git project folder.. this can cause people to lose changes/code easily after building. So instead changing the flow to;
- creating local git repo with `git init` 
- adding full state to an initial commit
- and updating the local `.gitignore` file to no longer exclude project source files, and exclude other files with sane defaults for any metagraph project