### PR TITLE
auto-migrate v1 hydra scaffolding folders to match ts version

### DIFF
--- a/src/main/config/loader.ts
+++ b/src/main/config/loader.ts
@@ -12,6 +12,7 @@ import {
   errorMessage,
 } from '../shared/errors.js';
 import { logger } from '../shared/logger.js';
+import { isLegacyScaffold, migrateScaffoldV1toV2 } from '../shared/scaffold-migration.js';
 
 const CONFIG_FILENAME = 'euclid.json';
 
@@ -88,6 +89,28 @@ export async function loadConfig(configPath?: string): Promise<EuclidConfig> {
     await writeConfigAtomic(resolvedPath, migrated);
     logger.info('Migration complete.');
     raw = migrated as unknown as Record<string, unknown>;
+  }
+
+  // Auto-migrate legacy v1 (Bash Hydra) scaffold layout to v2 (TS Hydra).
+  // Detection is filesystem-based (presence of infra/<image>/Dockerfile);
+  // after migration the infra/ directory is renamed so the trigger no
+  // longer fires on subsequent runs.
+  const projectRoot = dirname(resolvedPath);
+  if (isLegacyScaffold(projectRoot)) {
+    logger.info('Detected legacy (v1) scaffold layout — migrating to v2...');
+    migrateScaffoldV1toV2(projectRoot);
+    logger.info(
+      'Project layout is now:\n' +
+        '    data/             (was source/) — your code, wallets, genesis files\n' +
+        '    docker/           Docker build assets\n' +
+        '    infra.v1.backup/  old Docker build assets, kept for reference\n' +
+        '\n' +
+        '  Note: the old infra/<image>/Dockerfile and docker-compose.yml files are\n' +
+        '  NOT compatible with current Hydra build orchestration. Do not copy them into\n' +
+        '  docker/ directly. If you had customizations (volume mounts, port mappings,\n' +
+        '  env additions, etc.), re-express them in docker/custom/<image>/<file>.\n' +
+        '  Once verified, you can delete infra.v1.backup/.',
+    );
   }
 
   return validateConfig(raw);

--- a/src/main/shared/errors.ts
+++ b/src/main/shared/errors.ts
@@ -134,6 +134,18 @@ export class DockerVersionError extends DockerError {
   }
 }
 
+/**
+ * Thrown when an automatic scaffold migration can't proceed safely without
+ * user intervention (e.g. both old and new layout directories are present).
+ * Aborts the migration before any state mutation.
+ */
+export class ScaffoldMigrationBlockedError extends HydraError {
+  constructor(message: string, options?: { suggestion?: string }) {
+    super(message, { code: 'SCAFFOLD_MIGRATION_BLOCKED', ...options });
+    this.name = 'ScaffoldMigrationBlockedError';
+  }
+}
+
 /** Base error for local cluster operations. */
 export class ClusterError extends HydraError {
   constructor(message: string, options?: { suggestion?: string; cause?: Error }) {

--- a/src/main/shared/index.ts
+++ b/src/main/shared/index.ts
@@ -7,6 +7,7 @@ export {
   DockerError,
   DockerNotRunningError,
   DockerVersionError,
+  ScaffoldMigrationBlockedError,
   ClusterError,
   LayerStartError,
   RemoteError,

--- a/src/main/shared/scaffold-migration.ts
+++ b/src/main/shared/scaffold-migration.ts
@@ -1,0 +1,49 @@
+import { resolve } from 'node:path';
+import { existsSync, renameSync } from 'node:fs';
+import { ScaffoldMigrationBlockedError } from './errors.js';
+import { scaffoldProject } from './scaffold.js';
+
+/**
+ * Returns true if the project looks like the v1 (Bash Hydra) scaffold —
+ * filesystem-based heuristic, no marker file. After migration, infra/ is
+ * renamed to infra.v1.backup/, so this naturally returns false on subsequent
+ * runs. Mirrors the `isLegacyConfig` detection used for euclid.json.
+ *
+ * Signal: presence of `infra/metagraph-base-image/`. TS Hydra never creates
+ * `infra/`, so this is unambiguous in practice.
+ */
+export function isLegacyScaffold(projectRoot: string): boolean {
+  return existsSync(resolve(projectRoot, 'infra', 'metagraph-base-image'));
+}
+
+/**
+ * Migrate a v1 (Bash Hydra) project layout to v2 (TS Hydra) in place:
+ * `source/` → `data/`, scaffold bundled `docker/` assets, `infra/` →
+ * `infra.v1.backup/`. Throws `ScaffoldMigrationBlockedError` if both
+ * `source/` and `data/` are present (ambiguous state — needs manual
+ * intervention). Mirrors `migrateV1toV2` for euclid.json.
+ */
+export function migrateScaffoldV1toV2(projectRoot: string): void {
+  const sourceDir = resolve(projectRoot, 'source');
+  const dataDir = resolve(projectRoot, 'data');
+  const infraDir = resolve(projectRoot, 'infra');
+
+  if (existsSync(sourceDir) && existsSync(dataDir)) {
+    throw new ScaffoldMigrationBlockedError(
+      'Both source/ (old-Hydra) and data/ (TS-Hydra) are present — cannot auto-migrate.',
+      {
+        suggestion:
+          'Consolidate manually: move what you need from source/ into data/ and delete ' +
+          'source/, OR delete an empty data/ so the migration can rename source/ → data/.',
+      },
+    );
+  }
+
+  if (existsSync(sourceDir)) {
+    renameSync(sourceDir, dataDir);
+  }
+
+  scaffoldProject(projectRoot);
+
+  renameSync(infraDir, `${infraDir}.v1.backup`);
+}

--- a/src/tests/shared/scaffold-migration.test.ts
+++ b/src/tests/shared/scaffold-migration.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { resolve } from 'node:path';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { isLegacyScaffold, migrateScaffoldV1toV2 } from '../../main/shared/scaffold-migration.js';
+import { ScaffoldMigrationBlockedError } from '../../main/shared/errors.js';
+
+// scaffoldProject reads bundled assets from dist/assets/, which doesn't exist
+// when vitest runs against the TS source tree. Stub it out — these tests only
+// care about the rename + pre-flight logic that wraps it.
+vi.mock('../../main/shared/scaffold.js', () => ({
+  scaffoldProject: vi.fn((projectRoot: string) => {
+    // Mimic the parts of scaffoldProject that influence visible state in
+    // these tests: drop a sentinel docker/<image>/Dockerfile so callers can
+    // observe the scaffold ran.
+    mkdirSync(resolve(projectRoot, 'docker', 'metagraph-ubuntu'), { recursive: true });
+    writeFileSync(resolve(projectRoot, 'docker', 'metagraph-ubuntu', 'Dockerfile'), '# bundled');
+  }),
+}));
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(resolve(tmpdir(), 'scaffold-migration-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function makeOldHydraLayout(root: string): void {
+  // Minimal old-Hydra fixture mirroring what `current-main-euclid` looks like
+  // after a vanilla `hydra install`.
+  mkdirSync(resolve(root, 'infra', 'metagraph-base-image'), { recursive: true });
+  mkdirSync(resolve(root, 'infra', 'metagraph-ubuntu'), { recursive: true });
+  writeFileSync(resolve(root, 'infra', 'metagraph-base-image', 'Dockerfile'), '# old');
+  writeFileSync(resolve(root, 'infra', 'metagraph-ubuntu', 'Dockerfile'), '# old');
+  mkdirSync(resolve(root, 'source', 'project', 'custom-project'), { recursive: true });
+  mkdirSync(resolve(root, 'source', 'metagraph-l0', 'genesis'), { recursive: true });
+  mkdirSync(resolve(root, 'source', 'global-l0', 'genesis'), { recursive: true });
+  mkdirSync(resolve(root, 'source', 'p12-files'), { recursive: true });
+  writeFileSync(resolve(root, 'source', 'project', 'custom-project', 'build.sbt'), 'name := "x"');
+  writeFileSync(resolve(root, 'source', 'metagraph-l0', 'genesis', 'genesis.csv'), 'DAGabc,1000');
+  writeFileSync(resolve(root, 'source', 'p12-files', 'token-key.p12'), 'fake-p12');
+}
+
+describe('isLegacyScaffold', () => {
+  it('returns true when infra/metagraph-base-image/ exists', () => {
+    mkdirSync(resolve(tmpRoot, 'infra', 'metagraph-base-image'), { recursive: true });
+    expect(isLegacyScaffold(tmpRoot)).toBe(true);
+  });
+
+  it('returns false on a fresh / TS-Hydra-only project (no infra/)', () => {
+    mkdirSync(resolve(tmpRoot, 'docker', 'metagraph-ubuntu'), { recursive: true });
+    writeFileSync(resolve(tmpRoot, 'docker', 'metagraph-ubuntu', 'Dockerfile'), '');
+    expect(isLegacyScaffold(tmpRoot)).toBe(false);
+  });
+
+  it('returns false when infra/ exists but the metagraph-base-image/ subdir does not', () => {
+    mkdirSync(resolve(tmpRoot, 'infra', 'ansible'), { recursive: true });
+    expect(isLegacyScaffold(tmpRoot)).toBe(false);
+  });
+});
+
+describe('migrateScaffoldV1toV2', () => {
+  it('aborts when both source/ and data/ are present', () => {
+    makeOldHydraLayout(tmpRoot);
+    mkdirSync(resolve(tmpRoot, 'data'), { recursive: true });
+
+    expect(() => migrateScaffoldV1toV2(tmpRoot)).toThrow(ScaffoldMigrationBlockedError);
+
+    // No state mutation: source/, data/, infra/ all still in place
+    expect(existsSync(resolve(tmpRoot, 'source'))).toBe(true);
+    expect(existsSync(resolve(tmpRoot, 'data'))).toBe(true);
+    expect(existsSync(resolve(tmpRoot, 'infra'))).toBe(true);
+    expect(existsSync(resolve(tmpRoot, 'infra.v1.backup'))).toBe(false);
+  });
+
+  it('renames source/ → data/, scaffolds docker/, renames infra/ → infra.v1.backup/', () => {
+    makeOldHydraLayout(tmpRoot);
+
+    migrateScaffoldV1toV2(tmpRoot);
+
+    // source/ moved to data/, contents preserved
+    expect(existsSync(resolve(tmpRoot, 'source'))).toBe(false);
+    expect(existsSync(resolve(tmpRoot, 'data', 'project', 'custom-project', 'build.sbt'))).toBe(
+      true,
+    );
+    expect(existsSync(resolve(tmpRoot, 'data', 'metagraph-l0', 'genesis', 'genesis.csv'))).toBe(
+      true,
+    );
+    expect(existsSync(resolve(tmpRoot, 'data', 'p12-files', 'token-key.p12'))).toBe(true);
+
+    // scaffoldProject ran (mock dropped the sentinel)
+    expect(existsSync(resolve(tmpRoot, 'docker', 'metagraph-ubuntu', 'Dockerfile'))).toBe(true);
+
+    // infra/ parked as backup
+    expect(existsSync(resolve(tmpRoot, 'infra'))).toBe(false);
+    expect(
+      existsSync(resolve(tmpRoot, 'infra.v1.backup', 'metagraph-base-image', 'Dockerfile')),
+    ).toBe(true);
+  });
+
+  it('skips the source/ rename when source/ does not exist', () => {
+    // infra/ exists but source/ was already migrated/removed manually
+    mkdirSync(resolve(tmpRoot, 'infra', 'metagraph-base-image'), { recursive: true });
+    writeFileSync(resolve(tmpRoot, 'infra', 'metagraph-base-image', 'Dockerfile'), '');
+
+    expect(() => migrateScaffoldV1toV2(tmpRoot)).not.toThrow();
+
+    expect(existsSync(resolve(tmpRoot, 'infra'))).toBe(false);
+    expect(existsSync(resolve(tmpRoot, 'infra.v1.backup'))).toBe(true);
+    expect(existsSync(resolve(tmpRoot, 'docker', 'metagraph-ubuntu', 'Dockerfile'))).toBe(true);
+  });
+
+  it('is a no-op signal after a successful run (isLegacyScaffold becomes false)', () => {
+    makeOldHydraLayout(tmpRoot);
+    expect(isLegacyScaffold(tmpRoot)).toBe(true);
+
+    migrateScaffoldV1toV2(tmpRoot);
+
+    expect(isLegacyScaffold(tmpRoot)).toBe(false);
+  });
+});


### PR DESCRIPTION
when trying to use TS version in fresh current hydra project (or older metagraph projects built with hydra v1), it'll fail due mismatch of `source` vs `data` folder and `infra` folder vs `docker` folders, so auto migrating them similar to euclid.json migration with backups in place.