### PR TITLE
Fix jdk mismatch

### DIFF
--- a/docker/metagraph-ubuntu/Dockerfile
+++ b/docker/metagraph-ubuntu/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /code
 
 ARG CHECKOUT_TESSELLATION_VERSION
 ARG TESSELLATION_VERSION_IS_TAG_OR_BRANCH
+ARG JDK_VERSION=21
 
 ENV LC_ALL=C.UTF-8 \
     LANG=en_US.UTF-8 \
@@ -12,7 +13,7 @@ ENV LC_ALL=C.UTF-8 \
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      openjdk-21-jre curl gnupg lsof ca-certificates git && \
+      openjdk-${JDK_VERSION}-jre curl gnupg lsof ca-certificates git && \
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
     curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add - && \

--- a/docker/metagraph-ubuntu/docker-compose.yml
+++ b/docker/metagraph-ubuntu/docker-compose.yml
@@ -5,4 +5,5 @@ services:
       args:
         - CHECKOUT_TESSELLATION_VERSION
         - TESSELLATION_VERSION_IS_TAG_OR_BRANCH
+        - JDK_VERSION
     image: "metagraph-ubuntu-${TESSELLATION_VERSION_NAME}"

--- a/src/main/cli/commands/cluster/build.ts
+++ b/src/main/cli/commands/cluster/build.ts
@@ -68,6 +68,14 @@ export async function buildCommand(options: {
         ? `v${config.tessellation_version}`
         : config.tessellation_version;
 
+    // Tessellation 3 needs JDK 11, 4.x and beyond need JDK 21. Branch refs
+    // and other non-numeric versions default to 21.
+    const tessMajor = Number.parseInt(
+      config.tessellation_version.replace(/^v/, '').split('.')[0],
+      10,
+    );
+    const jdkVersion = Number.isFinite(tessMajor) && tessMajor < 4 ? '11' : '21';
+
     // Helper: update spinner text with Docker build output
     const streamTo =
       (spinner: ReturnType<typeof createSpinner>, prefix: string) => (line: string) => {
@@ -89,6 +97,7 @@ export async function buildCommand(options: {
         TESSELLATION_VERSION_NAME: tessVersionName,
         CHECKOUT_TESSELLATION_VERSION: checkoutVersion,
         TESSELLATION_VERSION_IS_TAG_OR_BRANCH: config.tessellation_ref_type,
+        JDK_VERSION: jdkVersion,
       },
       noCache: options.noCache,
       onOutput: streamTo(spinner1, 'metagraph-ubuntu:'),


### PR DESCRIPTION
When using TS hydra on mainNet which requires tessellation 3 with JDK 11 yet, it'll break due TS version defaulting to using JDK 21. 

Now reading which tessellation version is used, and switching JDK versions based on that. 4 and higher and default will be JDK 21 going forward, but if tessellation version is lower than 4, use JDK 11 instead.