### PR TITLE
support custom env vars in `euclid.json` applied to metagraph layers

### DIFF
--- a/euclid.json
+++ b/euclid.json
@@ -76,6 +76,9 @@
       "cli": 9402
     }
   },
+  "env_vars": {
+    "CL_COLLATERAL": "0"
+  },
   "snapshot_fees": {
     "owner": {
       "key_file": {

--- a/src/main/cluster/starters/dag-l1.ts
+++ b/src/main/cluster/starters/dag-l1.ts
@@ -5,6 +5,7 @@ import {
   nodeIp,
   nodePorts,
   baseEnv,
+  customEnv,
   copyP12,
   startJavaProcess,
   waitForReady,
@@ -32,6 +33,7 @@ export async function startDagL1(ctx: LayerContext): Promise<void> {
     CL_L0_PEER_HTTP_HOST: leadIp,
     CL_L0_PEER_HTTP_PORT: String(config.ports.global_l0.public),
     CL_L0_PEER_ID: ctx.leadNodeId,
+    ...customEnv(config),
   };
 
   ctx.onProgress?.('Starting DAG L1 initial validator...');
@@ -70,6 +72,7 @@ export async function startDagL1(ctx: LayerContext): Promise<void> {
       CL_L0_PEER_HTTP_HOST: leadIp,
       CL_L0_PEER_HTTP_PORT: String(config.ports.global_l0.public),
       CL_L0_PEER_ID: ctx.leadNodeId,
+      ...customEnv(config),
     };
 
     await startJavaProcess(

--- a/src/main/cluster/starters/helpers.ts
+++ b/src/main/cluster/starters/helpers.ts
@@ -97,6 +97,14 @@ export function metagraphL0PeerEnv(
   };
 }
 
+/**
+ * Resolve user-defined env vars from `config.env_vars`, applied to every
+ * metagraph layer. Returns `{}` when `env_vars` is unset.
+ */
+export function customEnv(config: EuclidConfig): Record<string, string> {
+  return config.env_vars ?? {};
+}
+
 /** Execute a command in a Docker container, throwing on non-zero exit. */
 export async function dockerExec(
   docker: DockerClient,

--- a/src/main/cluster/starters/l1-shared.ts
+++ b/src/main/cluster/starters/l1-shared.ts
@@ -6,6 +6,7 @@ import {
   nodeIp,
   nodePorts,
   baseEnv,
+  customEnv,
   globalL0PeerEnv,
   metagraphL0PeerEnv,
   copyP12,
@@ -43,6 +44,7 @@ export async function startL1Layer(
     ...baseEnv(leadNode, leadPorts),
     ...globalL0PeerEnv(config, ctx.leadNodeId),
     ...metagraphL0PeerEnv(config, ctx.leadNodeId),
+    ...customEnv(config),
     CL_L0_TOKEN_IDENTIFIER: ctx.metagraphId,
   };
 
@@ -83,6 +85,7 @@ export async function startL1Layer(
       ...baseEnv(valNode, valPorts),
       ...globalL0PeerEnv(config, ctx.leadNodeId),
       ...metagraphL0PeerEnv(config, ctx.leadNodeId),
+      ...customEnv(config),
       CL_L0_TOKEN_IDENTIFIER: ctx.metagraphId,
     };
 

--- a/src/main/cluster/starters/metagraph-l0.ts
+++ b/src/main/cluster/starters/metagraph-l0.ts
@@ -12,6 +12,7 @@ import {
   nodeIp,
   nodePorts,
   baseEnv,
+  customEnv,
   globalL0PeerEnv,
   copyP12,
   cleanLayerDirs,
@@ -162,6 +163,7 @@ export async function startMetagraphL0(ctx: LayerContext): Promise<void> {
   const envBase = {
     ...baseEnv(leadNode, leadPorts),
     ...globalL0PeerEnv(config, ctx.leadNodeId),
+    ...customEnv(config),
   };
 
   if (mode === 'genesis') {
@@ -359,6 +361,7 @@ export async function startMetagraphL0(ctx: LayerContext): Promise<void> {
     const valEnv = {
       ...baseEnv(valNode, valPorts),
       ...globalL0PeerEnv(config, ctx.leadNodeId),
+      ...customEnv(config),
       CL_L0_TOKEN_IDENTIFIER: ctx.metagraphId,
     };
 

--- a/src/main/config/schema.ts
+++ b/src/main/config/schema.ts
@@ -204,6 +204,20 @@ export const DeploySchema = z.object({
 /** Validated remote deployment configuration. */
 export type DeployConfig = z.infer<typeof DeploySchema>;
 
+// ─── Custom Env Vars Schema ──────────────────────────────────────────────────
+
+/**
+ * Zod schema for user-defined env vars — a flat string→string map applied to
+ * every metagraph layer (metagraph-l0, currency-l1, data-l1, dag-l1).
+ *
+ * Not applied to `global-l0`: that's the Constellation network L0, not part of
+ * the user's metagraph. User-set vars override the defaults built by `baseEnv`
+ * and the peer-env helpers.
+ */
+export const EnvVarsConfigSchema = z.record(z.string(), z.string());
+/** Validated user-defined env vars (flat string → string map). */
+export type EnvVarsConfig = z.infer<typeof EnvVarsConfigSchema>;
+
 // ─── Snapshot Fees Schema ────────────────────────────────────────────────────
 
 /** Zod schema for snapshot fee key configuration (owner + staking key files). */
@@ -241,6 +255,9 @@ export const EuclidConfigSchema = z.object({
 
   // Fees
   snapshot_fees: SnapshotFeesSchema.optional(),
+
+  // Custom env vars applied to every metagraph layer (not global-l0)
+  env_vars: EnvVarsConfigSchema.optional(),
 
   // Deployment (optional — only needed for remote operations)
   deploy: DeploySchema.optional(),

--- a/src/tests/config/schema.test.ts
+++ b/src/tests/config/schema.test.ts
@@ -175,6 +175,38 @@ describe('EuclidConfigSchema', () => {
     const result = EuclidConfigSchema.safeParse(withFees);
     expect(result.success).toBe(true);
   });
+
+  it('accepts env_vars as a flat string→string map', () => {
+    const withEnv = {
+      ...validConfig,
+      env_vars: {
+        CL_LOG_LEVEL: 'INFO',
+        CL_COLLATERAL: '250000',
+      },
+    };
+    const result = EuclidConfigSchema.safeParse(withEnv);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.env_vars?.CL_LOG_LEVEL).toBe('INFO');
+      expect(result.data.env_vars?.CL_COLLATERAL).toBe('250000');
+    }
+  });
+
+  it('rejects env_vars with non-string values', () => {
+    const result = EuclidConfigSchema.safeParse({
+      ...validConfig,
+      env_vars: { CL_COLLATERAL: 250000 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('treats omitted env_vars as undefined', () => {
+    const result = EuclidConfigSchema.safeParse(validConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.env_vars).toBeUndefined();
+    }
+  });
 });
 
 describe('isLegacyConfig', () => {


### PR DESCRIPTION
adding support for setting custom env vars in `euclid.json` to be applied to the running metagraph layers, useful for passing DB config strings etc. 