### PR TITLE
fix(seedlist): restore preflight in remote deploy/start; drop prompt …

### DIFF
--- a/src/main/cli/commands/remote/deploy.ts
+++ b/src/main/cli/commands/remote/deploy.ts
@@ -10,11 +10,13 @@ import {
 } from '../../../index.js';
 import type { PreflightIssue } from '../../../index.js';
 import { remoteDeploy } from '../../../remote/index.js';
+import { runSeedlistPreflight } from '../setup/check-seedlist.js';
 import { formatError } from '../../ui/format.js';
 import { t, icon } from '../../ui/theme.js';
 
 export async function remoteDeployCommand(options: {
   forceGenesis?: boolean;
+  skipSeedlist?: boolean;
   verbose?: boolean;
 }): Promise<void> {
   if (options.verbose) logger.setLevel(LogLevel.DEBUG);
@@ -59,6 +61,10 @@ export async function remoteDeployCommand(options: {
       process.stderr.write('\n');
       process.exit(1);
     }
+
+    await runSeedlistPreflight(config, config.deploy.network.name, projectRoot, {
+      skipSeedlist: options.skipSeedlist,
+    });
 
     const hostCount = config.deploy.hosts.length;
     const modeLabel = options.forceGenesis ? t.warn('Genesis') : t.accent('Update');

--- a/src/main/cli/commands/remote/start.ts
+++ b/src/main/cli/commands/remote/start.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
-import { loadConfig, logger, LogLevel } from '../../../index.js';
+import { loadConfig, findProjectRoot, logger, LogLevel } from '../../../index.js';
 import { remoteStart } from '../../../remote/index.js';
+import { runSeedlistPreflight } from '../setup/check-seedlist.js';
 import { DEFAULT_REMOTE_PORTS } from '../../../remote/defaults.js';
 import { t, icon } from '../../ui/theme.js';
 import { formatError } from '../../ui/format.js';
@@ -47,6 +48,7 @@ function renderProgress(step: string): void {
 
 export async function remoteStartCommand(options: {
   genesis?: boolean;
+  skipSeedlist?: boolean;
   verbose?: boolean;
 }): Promise<void> {
   if (options.verbose) logger.setLevel(LogLevel.DEBUG);
@@ -61,6 +63,11 @@ export async function remoteStartCommand(options: {
       );
       process.exit(1);
     }
+
+    const projectRoot = findProjectRoot();
+    await runSeedlistPreflight(config, config.deploy.network.name, projectRoot, {
+      skipSeedlist: options.skipSeedlist,
+    });
 
     const modeLabel = options.genesis ? t.warn('Genesis') : t.accent('Rollback');
     process.stdout.write(`\n  ${chalk.bold('Remote Start')} ${t.dim('—')} ${modeLabel} mode\n`);

--- a/src/main/cli/commands/setup/check-seedlist.ts
+++ b/src/main/cli/commands/setup/check-seedlist.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { confirm } from '@inquirer/prompts';
+import type { EuclidConfig } from '../../../config/schema.js';
 import { loadConfig, findProjectRoot, logger, LogLevel } from '../../../index.js';
 import { formatError, formatSuccess, formatWarning, formatHeader } from '../../ui/format.js';
 import { t, icon } from '../../ui/theme.js';
@@ -13,6 +14,76 @@ const SEEDLIST_URLS: Record<string, string> = {
   mainnet:
     'https://github.com/Constellation-Labs/tessellation/releases/latest/download/mainnet-seedlist',
 };
+
+/**
+ * Iterate over every configured node, extract its peer ID via cl-wallet.jar,
+ * and check it against the fetched seedlist. Prints per-node status inline.
+ * Returns true iff every node's peer ID was found on the seedlist.
+ *
+ * Shared by `checkSeedlistCommand` (standalone diagnostic) and
+ * `runSeedlistPreflight` (gate before remote deploy/start) so the per-node
+ * iteration logic doesn't drift between the two.
+ */
+function checkNodesAgainstSeedlist(
+  config: EuclidConfig,
+  seedlist: string,
+  network: string,
+  walletJar: string,
+  p12Dir: string,
+): boolean {
+  let allFound = true;
+
+  for (const node of config.nodes) {
+    const keyFile = node.key_file;
+    const p12Path = resolve(p12Dir, keyFile.name);
+
+    if (!existsSync(p12Path)) {
+      process.stdout.write(
+        `  ${formatWarning(`${node.name}: P12 file not found (${keyFile.name})`)}\n`,
+      );
+      allFound = false;
+      continue;
+    }
+
+    try {
+      const peerId = execFileSync('java', ['-jar', walletJar, 'show-id'], {
+        cwd: p12Dir,
+        env: {
+          ...process.env,
+          CL_KEYSTORE: keyFile.name,
+          CL_KEYALIAS: keyFile.alias,
+          CL_PASSWORD: keyFile.password,
+        },
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+
+      if (!peerId) {
+        process.stdout.write(`  ${formatWarning(`${node.name}: Failed to extract peer ID`)}\n`);
+        allFound = false;
+        continue;
+      }
+
+      if (seedlist.includes(peerId)) {
+        process.stdout.write(
+          `  ${formatSuccess(`${node.name} (${peerId.slice(0, 16)}...) found on seedlist`)}\n`,
+        );
+      } else {
+        process.stdout.write(
+          `  ${formatWarning(`${node.name} (${peerId.slice(0, 16)}...) NOT found on ${network} seedlist`)}\n`,
+        );
+        allFound = false;
+      }
+    } catch (err) {
+      process.stdout.write(
+        `  ${formatWarning(`${node.name}: Error extracting peer ID — ${err instanceof Error ? err.message : String(err)}`)}\n`,
+      );
+      allFound = false;
+    }
+  }
+
+  return allFound;
+}
 
 export async function checkSeedlistCommand(options: {
   network: string;
@@ -46,11 +117,8 @@ export async function checkSeedlistCommand(options: {
 
     process.stdout.write(formatHeader(`Seedlist Check (${network})`));
 
-    // Fetch seedlist
     process.stdout.write('  Fetching seedlist...\n');
-    const response = await fetch(SEEDLIST_URLS[network], {
-      signal: AbortSignal.timeout(30000),
-    });
+    const response = await fetch(SEEDLIST_URLS[network], { signal: AbortSignal.timeout(30000) });
 
     if (!response.ok) {
       process.stderr.write(
@@ -67,58 +135,7 @@ export async function checkSeedlistCommand(options: {
 
     process.stdout.write(`  ${formatSuccess('Seedlist fetched')}\n\n`);
 
-    // Check each node
-    let allFound = true;
-
-    for (const node of config.nodes) {
-      const keyFile = node.key_file;
-      const p12Path = resolve(p12Dir, keyFile.name);
-
-      if (!existsSync(p12Path)) {
-        process.stdout.write(
-          `  ${formatWarning(`${node.name}: P12 file not found (${keyFile.name})`)}\n`,
-        );
-        allFound = false;
-        continue;
-      }
-
-      try {
-        // Extract peer ID using cl-wallet.jar
-        const peerId = execFileSync('java', ['-jar', walletJar, 'show-id'], {
-          cwd: p12Dir,
-          env: {
-            ...process.env,
-            CL_KEYSTORE: keyFile.name,
-            CL_KEYALIAS: keyFile.alias,
-            CL_PASSWORD: keyFile.password,
-          },
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-        }).trim();
-
-        if (!peerId) {
-          process.stdout.write(`  ${formatWarning(`${node.name}: Failed to extract peer ID`)}\n`);
-          allFound = false;
-          continue;
-        }
-
-        if (seedlist.includes(peerId)) {
-          process.stdout.write(
-            `  ${formatSuccess(`${node.name} (${peerId.slice(0, 16)}...) found on seedlist`)}\n`,
-          );
-        } else {
-          process.stdout.write(
-            `  ${formatWarning(`${node.name} (${peerId.slice(0, 16)}...) NOT found on ${network} seedlist`)}\n`,
-          );
-          allFound = false;
-        }
-      } catch (err) {
-        process.stdout.write(
-          `  ${formatWarning(`${node.name}: Error extracting peer ID — ${err instanceof Error ? err.message : String(err)}`)}\n`,
-        );
-        allFound = false;
-      }
-    }
+    const allFound = checkNodesAgainstSeedlist(config, seedlist, network, walletJar, p12Dir);
 
     process.stdout.write('\n');
 
@@ -129,21 +146,81 @@ export async function checkSeedlistCommand(options: {
       process.stdout.write(
         `  Ensure your peer IDs are registered before proceeding on ${network}.\n\n`,
       );
-
-      const proceed = await confirm({
-        message: 'Continue anyway?',
-        default: false,
-      });
-
-      if (!proceed) {
-        process.stdout.write('\n  Aborting.\n\n');
-        process.exit(1);
-      }
-    } else {
-      process.stdout.write(`  ${formatSuccess('All nodes found on seedlist!')}\n\n`);
+      process.exit(1);
     }
+
+    process.stdout.write(`  ${formatSuccess('All nodes found on seedlist!')}\n\n`);
   } catch (err) {
     process.stderr.write('\n' + formatError(err) + '\n');
+    process.exit(1);
+  }
+}
+
+/**
+ * Seedlist preflight gate for remote deploy/start. No-op for networks other
+ * than integrationnet/mainnet. On missing peers, prompts the user (TTY) or
+ * aborts (non-TTY); `--skip-seedlist` bypasses entirely.
+ *
+ * Restores parity with old hydra's `check_seedlist` call inside
+ * `remote_deploy_metagraph` / `remote_start_metagraph`.
+ */
+export async function runSeedlistPreflight(
+  config: EuclidConfig,
+  network: string,
+  projectRoot: string,
+  options: { skipSeedlist?: boolean } = {},
+): Promise<void> {
+  if (network !== 'integrationnet' && network !== 'mainnet') return;
+
+  if (options.skipSeedlist) {
+    process.stdout.write(
+      `  ${icon.warn} ${t.warn(`Skipping ${network} seedlist preflight (--skip-seedlist).`)}\n\n`,
+    );
+    return;
+  }
+
+  const walletJar = resolve(projectRoot, 'docker', 'artifacts', 'jars', 'cl-wallet.jar');
+  if (!existsSync(walletJar)) {
+    process.stdout.write(
+      `  ${formatWarning("cl-wallet.jar not found. Skipping seedlist check (run 'hydra build' first).")}\n\n`,
+    );
+    return;
+  }
+
+  process.stdout.write(`\n  Checking ${network} seedlist registration...\n`);
+
+  const response = await fetch(SEEDLIST_URLS[network], { signal: AbortSignal.timeout(30000) });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${network} seedlist (HTTP ${response.status})`);
+  }
+  const seedlist = (await response.text()).trim();
+  if (!seedlist) throw new Error(`Empty ${network} seedlist received.`);
+
+  const p12Dir = resolve(projectRoot, 'data', 'p12-files');
+  const allFound = checkNodesAgainstSeedlist(config, seedlist, network, walletJar, p12Dir);
+
+  process.stdout.write('\n');
+
+  if (allFound) {
+    process.stdout.write(`  ${formatSuccess('All nodes found on seedlist.')}\n\n`);
+    return;
+  }
+
+  process.stdout.write(
+    `  ${formatWarning('One or more node peer IDs are not on the seedlist.')}\n` +
+      `  Ensure your peer IDs are registered before proceeding on ${network}.\n\n`,
+  );
+
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      `  ${icon.error} ${t.error('Aborting: no TTY to confirm. Re-run with --skip-seedlist to override.')}\n\n`,
+    );
+    process.exit(1);
+  }
+
+  const proceed = await confirm({ message: 'Continue anyway?', default: false });
+  if (!proceed) {
+    process.stdout.write('\n  Aborting.\n\n');
     process.exit(1);
   }
 }

--- a/src/main/cli/index.ts
+++ b/src/main/cli/index.ts
@@ -303,18 +303,28 @@ remoteCmd
   .command('deploy')
   .description('Deploy JARs and keys to remote hosts')
   .option('--force-genesis', 'Force genesis file upload even if data exists')
+  .option('--skip-seedlist', 'Skip the integrationnet/mainnet seedlist preflight check')
   .action(async (cmdOpts) => {
     const opts = program.opts();
-    await remoteDeployCommand({ forceGenesis: cmdOpts.forceGenesis, verbose: opts.verbose });
+    await remoteDeployCommand({
+      forceGenesis: cmdOpts.forceGenesis,
+      skipSeedlist: cmdOpts.skipSeedlist,
+      verbose: opts.verbose,
+    });
   });
 
 remoteCmd
   .command('start')
   .description('Start the remote metagraph cluster')
   .option('--genesis', 'Start from genesis (erases history)')
+  .option('--skip-seedlist', 'Skip the integrationnet/mainnet seedlist preflight check')
   .action(async (cmdOpts) => {
     const opts = program.opts();
-    await remoteStartCommand({ genesis: cmdOpts.genesis, verbose: opts.verbose });
+    await remoteStartCommand({
+      genesis: cmdOpts.genesis,
+      skipSeedlist: cmdOpts.skipSeedlist,
+      verbose: opts.verbose,
+    });
   });
 
 remoteCmd


### PR DESCRIPTION
the seedlist check command `hydra check-seedlist mainnet` was prompting the user to "continue" at the end which was doing nothing so it's only confusing, improving that command with this PR.