### PR TITLE
add keystore-info command to show all p12 details easier

### DIFF
--- a/src/main/cli/commands/setup/keystore-info.ts
+++ b/src/main/cli/commands/setup/keystore-info.ts
@@ -1,0 +1,105 @@
+import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import {
+  loadConfig,
+  findProjectRoot,
+  logger,
+  LogLevel,
+  type KeyFileConfig,
+} from '../../../index.js';
+import { formatError, formatWarning } from '../../ui/format.js';
+import { t, icon } from '../../ui/theme.js';
+
+interface KeystoreEntry {
+  label: string;
+  keyFile: KeyFileConfig;
+}
+
+export async function keystoreInfoCommand(options: { verbose?: boolean }): Promise<void> {
+  if (options.verbose) logger.setLevel(LogLevel.DEBUG);
+
+  try {
+    const config = await loadConfig();
+    const projectRoot = findProjectRoot();
+    const walletJar = resolve(projectRoot, 'docker', 'artifacts', 'jars', 'cl-wallet.jar');
+    const p12Dir = resolve(projectRoot, 'data', 'p12-files');
+
+    if (!existsSync(walletJar)) {
+      process.stderr.write(
+        `\n  ${icon.error} ${t.error("cl-wallet.jar not found. Run 'hydra build' first.")}\n\n`,
+      );
+      process.exit(1);
+    }
+
+    const entries: KeystoreEntry[] = [];
+    for (const node of config.nodes) {
+      entries.push({ label: node.name, keyFile: node.key_file });
+    }
+    if (config.snapshot_fees) {
+      entries.push({
+        label: 'snapshot_fees.owner',
+        keyFile: config.snapshot_fees.owner.key_file,
+      });
+      entries.push({
+        label: 'snapshot_fees.staking',
+        keyFile: config.snapshot_fees.staking.key_file,
+      });
+    }
+
+    process.stdout.write('\n');
+
+    for (const entry of entries) {
+      const p12Path = resolve(p12Dir, entry.keyFile.name);
+
+      process.stdout.write(`  ${t.accent(entry.label)} ${t.dim(`(${entry.keyFile.name})`)}\n`);
+
+      if (!existsSync(p12Path)) {
+        process.stdout.write(`    ${formatWarning(`P12 file not found at ${p12Path}`)}\n\n`);
+        continue;
+      }
+
+      const env = {
+        ...process.env,
+        CL_KEYSTORE: entry.keyFile.name,
+        CL_KEYALIAS: entry.keyFile.alias,
+        CL_PASSWORD: entry.keyFile.password,
+      };
+
+      const address = runWallet(walletJar, p12Dir, env, 'show-address');
+      const peerId = runWallet(walletJar, p12Dir, env, 'show-id');
+
+      process.stdout.write(
+        `    ${t.dim('DAG address:')} ${address.ok ? address.value : t.error(address.error)}\n`,
+      );
+      process.stdout.write(
+        `    ${t.dim('Peer ID:')}     ${peerId.ok ? peerId.value : t.error(peerId.error)}\n\n`,
+      );
+    }
+  } catch (err) {
+    process.stderr.write('\n' + formatError(err) + '\n');
+    process.exit(1);
+  }
+}
+
+type WalletResult = { ok: true; value: string } | { ok: false; error: string };
+
+function runWallet(
+  walletJar: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  cmd: string,
+): WalletResult {
+  try {
+    const out = execFileSync('java', ['-jar', walletJar, cmd], {
+      cwd,
+      env,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (!out) return { ok: false, error: `empty output from cl-wallet.jar ${cmd}` };
+    return { ok: true, value: out };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/main/cli/index.ts
+++ b/src/main/cli/index.ts
@@ -30,6 +30,7 @@ import { createRemoteGenesisCommand } from './commands/remote/create-genesis.js'
 import { updateCommand } from './commands/setup/update.js';
 import { checkSeedlistCommand } from './commands/setup/check-seedlist.js';
 import { keygenCommand } from './commands/setup/keygen.js';
+import { keystoreInfoCommand } from './commands/setup/keystore-info.js';
 import { remoteDeployCommand } from './commands/remote/deploy.js';
 import { remoteStartCommand } from './commands/remote/start.js';
 import { remoteStatusCommand } from './commands/remote/status.js';
@@ -272,6 +273,16 @@ program
   .action(async (network) => {
     const opts = program.opts();
     await checkSeedlistCommand({ network, verbose: opts.verbose });
+  });
+
+// ─── keystore-info ──────────────────────────────────────────────────────────
+
+program
+  .command('keystore-info')
+  .description('Show DAG addresses and peer IDs for keystores')
+  .action(async () => {
+    const opts = program.opts();
+    await keystoreInfoCommand({ verbose: opts.verbose });
   });
 
 // ─── keygen ─────────────────────────────────────────────────────────────────

--- a/src/main/cli/menu/interactive.ts
+++ b/src/main/cli/menu/interactive.ts
@@ -23,6 +23,7 @@ import { createRemoteGenesisCommand } from '../commands/remote/create-genesis.js
 import { updateCommand } from '../commands/setup/update.js';
 import { checkSeedlistCommand } from '../commands/setup/check-seedlist.js';
 import { keygenCommand } from '../commands/setup/keygen.js';
+import { keystoreInfoCommand } from '../commands/setup/keystore-info.js';
 import { remoteDeployCommand } from '../commands/remote/deploy.js';
 import { remoteStartCommand } from '../commands/remote/start.js';
 import { remoteStatusCommand } from '../commands/remote/status.js';
@@ -257,6 +258,10 @@ function buildMenuChoices() {
       name: `check-seedlist           ${t.dim('Verify seedlist registration')}`,
       value: 'check-seedlist',
     },
+    {
+      name: `keystore-info            ${t.dim('Show DAG addresses and peer IDs for keystores')}`,
+      value: 'keystore-info',
+    },
 
     new Separator(''),
     new Separator(`  ${t.dim('─'.repeat(44))}`),
@@ -436,6 +441,9 @@ async function executeCommand(command: string): Promise<void> {
 
     case 'keygen':
       return keygenCommand({ verbose });
+
+    case 'keystore-info':
+      return keystoreInfoCommand({ verbose });
 
     // ── Remote commands ───────────────────────────────────────────────
 


### PR DESCRIPTION
adding a new command called `keystore-info` to get all p12 details easier for setting up deployments. People can use it to get their peer-ids for being added to the seedlists and public dag addresses to fund owner wallets etc.