### PR TITLE
dedupe signer proofs

### DIFF
--- a/src/main/cluster/fees.ts
+++ b/src/main/cluster/fees.ts
@@ -52,12 +52,29 @@ export function combineSignedMessages(signedOutputs: string[]): SignedMessage {
     }
   }
 
+  // Merge proofs, dropping any repeated signer id. A single distinct proof per
+  // signer is what Tessellation expects.
+  const seen = new Set<string>();
+  const proofs: SignedProof[] = [];
+  for (const message of parsed) {
+    for (const proof of message.proofs) {
+      if (seen.has(proof.id)) {
+        logger.debug(`Skipping duplicate proof from signer ${proof.id}`);
+        continue;
+      }
+      seen.add(proof.id);
+      proofs.push(proof);
+    }
+  }
+
   const combined: SignedMessage = {
     value: parsed[0].value,
-    proofs: parsed.flatMap((m) => m.proofs),
+    proofs,
   };
 
-  logger.debug(`Combined ${parsed.length} signed messages → ${combined.proofs.length} proofs`);
+  logger.debug(
+    `Combined ${parsed.length} signed messages → ${combined.proofs.length} distinct proofs`,
+  );
   return combined;
 }
 

--- a/src/tests/cluster/fees.test.ts
+++ b/src/tests/cluster/fees.test.ts
@@ -31,7 +31,7 @@ describe('combineSignedMessages', () => {
     expect(result.proofs.map((p) => p.id)).toEqual(['peer1', 'peer2', 'peer3']);
   });
 
-  it('flattens multiple proofs from same message', () => {
+  it('dedupes repeated signer ids within a single message, keeping the first', () => {
     const value = { amount: 50 };
     const msg1 = makeSignedMessage(value, [
       { id: 'peer1', signature: 'sig1a' },
@@ -40,7 +40,23 @@ describe('combineSignedMessages', () => {
     const msg2 = makeSignedMessage(value, [{ id: 'peer2', signature: 'sig2' }]);
 
     const result = combineSignedMessages([msg1, msg2]);
+    expect(result.proofs).toHaveLength(2);
+    expect(result.proofs.map((p) => p.id)).toEqual(['peer1', 'peer2']);
+    // first occurrence wins
+    expect(result.proofs.find((p) => p.id === 'peer1')?.signature).toBe('sig1a');
+  });
+
+  it('dedupes the same signer across separate messages (owner key == node key)', () => {
+    // Tessellation rejects the duplicate with DuplicateSigners, combine must collapse it.
+    const value = { address: 'DAG_owner', metagraphId: 'DAG_mg', parentOrdinal: 0 };
+    const ownerSigned = makeSignedMessage(value, [{ id: 'node1', signature: 'owner-sig' }]);
+    const node1Signed = makeSignedMessage(value, [{ id: 'node1', signature: 'node1-sig' }]);
+    const node2Signed = makeSignedMessage(value, [{ id: 'node2', signature: 'node2-sig' }]);
+    const node3Signed = makeSignedMessage(value, [{ id: 'node3', signature: 'node3-sig' }]);
+
+    const result = combineSignedMessages([ownerSigned, node1Signed, node2Signed, node3Signed]);
     expect(result.proofs).toHaveLength(3);
+    expect(result.proofs.map((p) => p.id)).toEqual(['node1', 'node2', 'node3']);
   });
 
   it('throws LayerStartError for empty input', () => {


### PR DESCRIPTION
when having a single key configured in euclid for multiple purposes, e.g. node-1 key and owner key share the same p12 file, euclid is trying to sign proofs with the same key twice, which will cause `DuplicateSigners` errors when trying to deploy.

We should use a set to ensure unique signatures, to prevent this