### PR TITLE
lower default jvm heap sizes to pre-ts values

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,9 +439,9 @@ Hydra uses `euclid.json` at the project root. The CLI auto-discovers it by walki
       }
     },
     "jvm": {
-      "metagraph_l0": { "xms": "8g", "xmx": "8g" },
-      "currency_l1":  { "xms": "4g", "xmx": "4g" },
-      "data_l1":      { "xms": "4g", "xmx": "4g" }
+      "metagraph_l0": { "xms": "1g", "xmx": "4g" },
+      "currency_l1":  { "xms": "1g", "xmx": "2g" },
+      "data_l1":      { "xms": "1g", "xmx": "2g" }
     },
     "hosts": [
       { "host": "1.2.3.4",    "user": "ubuntu", "ssh_key": "~/.ssh/id_rsa" },
@@ -466,7 +466,7 @@ Hydra uses `euclid.json` at the project root. The CLI auto-discovers it by walki
 
 - **`hosts` ↔ `nodes`** — They map 1:1. Host-1 runs node-1, host-2 runs node-2, etc.
 - **`remote_ports`** — Different from local ports because each remote host runs one node (not multiple containers).
-- **`jvm`** — Each layer has its own `-Xms` / `-Xmx` heap settings. Defaults: 8g for Metagraph L0, 4g for Currency L1 and Data L1. Values must be like `"8g"` or `"512m"`.
+- **`jvm`** — Each layer has its own `-Xms` / `-Xmx` heap settings. Defaults: 1g min for all layers; max 4g for Metagraph L0, 2g for Currency L1 and Data L1. Values must be like `"8g"` or `"512m"`.
 - **`monitoring_host`** — Used by `remote deploy-monitoring` and `remote start-monitoring`.
 - **`docker`**, **`ports`**, **`jvm`**, and **`remote_ports`** all have sensible defaults — you only need to set them if you want to customize.
 

--- a/euclid.json
+++ b/euclid.json
@@ -102,9 +102,9 @@
       }
     },
     "jvm": {
-      "metagraph_l0": { "xms": "8g", "xmx": "8g" },
-      "currency_l1": { "xms": "4g", "xmx": "4g" },
-      "data_l1": { "xms": "4g", "xmx": "4g" }
+      "metagraph_l0": { "xms": "1g", "xmx": "4g" },
+      "currency_l1": { "xms": "1g", "xmx": "2g" },
+      "data_l1": { "xms": "1g", "xmx": "2g" }
     },
     "monitoring_host": {
       "host": "13.14.15.16",

--- a/src/main/config/migration.ts
+++ b/src/main/config/migration.ts
@@ -83,16 +83,16 @@ function migrateDeployConfig(oldDeploy: LegacyEuclidConfig['deploy']): DeployCon
     },
     jvm: {
       metagraph_l0: {
-        xms: oldDeploy.jvm?.min_heap ?? '8g',
-        xmx: oldDeploy.jvm?.max_heap ?? '8g',
+        xms: oldDeploy.jvm?.min_heap ?? '1g',
+        xmx: oldDeploy.jvm?.max_heap ?? '4g',
       },
       currency_l1: {
-        xms: oldDeploy.jvm?.min_heap ?? '4g',
-        xmx: oldDeploy.jvm?.max_heap ?? '4g',
+        xms: oldDeploy.jvm?.min_heap ?? '1g',
+        xmx: oldDeploy.jvm?.max_heap ?? '2g',
       },
       data_l1: {
-        xms: oldDeploy.jvm?.min_heap ?? '4g',
-        xmx: oldDeploy.jvm?.max_heap ?? '4g',
+        xms: oldDeploy.jvm?.min_heap ?? '1g',
+        xmx: oldDeploy.jvm?.max_heap ?? '2g',
       },
     },
     // ansible is stripped — v2 uses native SSH via deploy.hosts

--- a/src/main/config/schema.ts
+++ b/src/main/config/schema.ts
@@ -116,15 +116,15 @@ export type JvmLayerConfig = { xms: string; xmx: string };
  * Per-layer JVM config. Each layer has its own -Xms and -Xmx settings.
  *
  * Defaults:
- *   metagraph_l0: xms=8g, xmx=8g
- *   currency_l1:  xms=4g, xmx=4g
- *   data_l1:      xms=4g, xmx=4g
+ *   metagraph_l0: xms=1g, xmx=4g
+ *   currency_l1:  xms=1g, xmx=2g
+ *   data_l1:      xms=1g, xmx=2g
  */
 export const LayerJvmConfigSchema = z
   .object({
-    metagraph_l0: jvmLayerSchema('8g', '8g'),
-    currency_l1: jvmLayerSchema('4g', '4g'),
-    data_l1: jvmLayerSchema('4g', '4g'),
+    metagraph_l0: jvmLayerSchema('1g', '4g'),
+    currency_l1: jvmLayerSchema('1g', '2g'),
+    data_l1: jvmLayerSchema('1g', '2g'),
   })
   .default({});
 /** Validated per-layer JVM heap configuration. */

--- a/src/tests/config/resolve-jvm.test.ts
+++ b/src/tests/config/resolve-jvm.test.ts
@@ -14,22 +14,22 @@ import {
 // ─── resolveJvmConfig ────────────────────────────────────────────────────────
 
 describe('resolveJvmConfig', () => {
-  it('returns metagraph_l0 defaults (8g)', () => {
+  it('returns metagraph_l0 defaults (1g/4g)', () => {
     const jvm = LayerJvmConfigSchema.parse({});
     const result = resolveJvmConfig(jvm, 'metagraph_l0');
-    expect(result).toEqual({ xms: '8g', xmx: '8g' });
+    expect(result).toEqual({ xms: '1g', xmx: '4g' });
   });
 
-  it('returns currency_l1 defaults (4g)', () => {
+  it('returns currency_l1 defaults (1g/2g)', () => {
     const jvm = LayerJvmConfigSchema.parse({});
     const result = resolveJvmConfig(jvm, 'currency_l1');
-    expect(result).toEqual({ xms: '4g', xmx: '4g' });
+    expect(result).toEqual({ xms: '1g', xmx: '2g' });
   });
 
-  it('returns data_l1 defaults (4g)', () => {
+  it('returns data_l1 defaults (1g/2g)', () => {
     const jvm = LayerJvmConfigSchema.parse({});
     const result = resolveJvmConfig(jvm, 'data_l1');
-    expect(result).toEqual({ xms: '4g', xmx: '4g' });
+    expect(result).toEqual({ xms: '1g', xmx: '2g' });
   });
 
   it('uses custom values per layer', () => {
@@ -40,15 +40,15 @@ describe('resolveJvmConfig', () => {
     expect(resolveJvmConfig(jvm, 'metagraph_l0')).toEqual({ xms: '16g', xmx: '16g' });
     expect(resolveJvmConfig(jvm, 'currency_l1')).toEqual({ xms: '2g', xmx: '6g' });
     // data_l1 untouched — keeps defaults
-    expect(resolveJvmConfig(jvm, 'data_l1')).toEqual({ xms: '4g', xmx: '4g' });
+    expect(resolveJvmConfig(jvm, 'data_l1')).toEqual({ xms: '1g', xmx: '2g' });
   });
 
   it('partial override fills remaining from defaults', () => {
     const jvm = LayerJvmConfigSchema.parse({
       metagraph_l0: { xmx: '12g' },
     });
-    // xms comes from metagraph_l0 default (8g), xmx from override (12g)
-    expect(resolveJvmConfig(jvm, 'metagraph_l0')).toEqual({ xms: '8g', xmx: '12g' });
+    // xms comes from metagraph_l0 default (1g), xmx from override (12g)
+    expect(resolveJvmConfig(jvm, 'metagraph_l0')).toEqual({ xms: '1g', xmx: '12g' });
   });
 });
 
@@ -58,9 +58,9 @@ describe('LayerJvmConfigSchema', () => {
   it('provides full defaults when given empty object', () => {
     const result = LayerJvmConfigSchema.safeParse({});
     expect(result.success).toBe(true);
-    expect(result.data?.metagraph_l0).toEqual({ xms: '8g', xmx: '8g' });
-    expect(result.data?.currency_l1).toEqual({ xms: '4g', xmx: '4g' });
-    expect(result.data?.data_l1).toEqual({ xms: '4g', xmx: '4g' });
+    expect(result.data?.metagraph_l0).toEqual({ xms: '1g', xmx: '4g' });
+    expect(result.data?.currency_l1).toEqual({ xms: '1g', xmx: '2g' });
+    expect(result.data?.data_l1).toEqual({ xms: '1g', xmx: '2g' });
   });
 
   it('accepts partial layer overrides', () => {
@@ -68,7 +68,7 @@ describe('LayerJvmConfigSchema', () => {
       metagraph_l0: { xmx: '12g' },
     });
     expect(result.success).toBe(true);
-    expect(result.data?.metagraph_l0.xms).toBe('8g'); // default
+    expect(result.data?.metagraph_l0.xms).toBe('1g'); // default
     expect(result.data?.metagraph_l0.xmx).toBe('12g'); // overridden
   });
 


### PR DESCRIPTION
new TS branch is setting higher values for JVM heap sizes causing issues, I think it's better to keep the previous values